### PR TITLE
Add libxml2-dev and libxslt1-dev to the list of required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 # Development environment
 ## Step 1 - System dependencies
 ```
-sudo apt install git virtualenv postgresql-9.6 rabbitmq-server tshark aapt build-essential libssl-dev aapt libffi-dev python3-dev openjdk-8-jre
+sudo apt install git virtualenv postgresql-9.6 rabbitmq-server tshark aapt build-essential libssl-dev aapt libffi-dev python3-dev openjdk-8-jre libxml2-dev libxslt1-dev
 ```
 
 ## Step 2 - Clone the project


### PR DESCRIPTION
Without libxml2-dev and libxslt1-dev installed on the system the build process fails when trying to install lxml.

This PR adds the good packages in the lists of packages to install.