### PR TITLE
Fix Minio URL in Ansible playbook

### DIFF
--- a/provisioning/minio/tasks/main.yml
+++ b/provisioning/minio/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: download minio
   get_url:
-    url: https://dl.minio.io/server/minio/release/linux-amd64/minio
+    url: https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2018-02-09T22-40-05Z
     checksum: sha256:98cf1e082368e3f57f2be39dd49b1abffca4068e6d3e859f300ae93b4e5f6a5a
     dest: ~/minio
     mode: u+x


### PR DESCRIPTION
I just tried to install the Exodus project on my local machine, with the suggested Vagrant method (my git HEAD is 8653218). However, in the “vagrant up” command, the ansible playbook fails at task “minio : download minio”, with the following error:

> fatal: [default]: FAILED! => {"changed": false, "msg": "The checksum for /home/vagrant/minio did not match 98cf1e082368e3f57f2be39dd49b1abffca4068e6d3e859f300ae93b4e5f6a5a; it was 892b139cd620c48cd1ca5e0c41c1ea7f3320b7ec4fdccebac750efe04dd52480."}

In the file `provisioning/minio/tasks/main.yml`, the URL for Minio executable doesn’t contain the version number, so whenever a new Minio is released, the target changes, with its checksum.

I found that the exact version targeted by the actual playbook is [RELEASE.2018-02-09T22-40-05Z](https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2018-02-09T22-40-05Z). This PR fixes the ansible playbook with a definitive URL.