### PR TITLE
Use the _compile_trackers method

### DIFF
--- a/exodus/exodus/core/static_analysis.py
+++ b/exodus/exodus/core/static_analysis.py
@@ -26,6 +26,7 @@ class StaticAnalysis(CoreSA):
         Load trackers signatures from database.
         """
         self.signatures = Tracker.objects.order_by('name')
+        self._compile_signatures()
 
     def get_application_icon(self, storage, icon_name):
         with NamedTemporaryFile() as f:


### PR DESCRIPTION
Add the pre-compilation of regexes in the load_trackers_signature method.

Requires the validation of https://github.com/Exodus-Privacy/exodus-core/pull/4 