### PR TITLE
Add tracker links on the Most frequent trackers page

### DIFF
--- a/exodus/reports/templates/stats_details.html
+++ b/exodus/reports/templates/stats_details.html
@@ -14,7 +14,7 @@
             {% for t in trackers %}
             <tr>
                 <td class="text-right">
-                  {{t.name}}
+                  <a href="{% url 'trackers:detail' t.id %}">{{t.name}} </a>
                 </td>
                 <td class="small text-muted">
                     found in {{t.count}} app{{ t.count|pluralize }}

--- a/exodus/reports/templates/stats_details.html
+++ b/exodus/reports/templates/stats_details.html
@@ -11,22 +11,26 @@
             </div>
             <hr>
             <table style="margin: auto">
-            {% for result in trackers %}
-            <tr><td class="text-right">{{result.name}} </td>
+            {% for t in trackers %}
+            <tr>
+                <td class="text-right">
+                  {{t.name}}
+                </td>
                 <td class="small text-muted">
-                    found in {{result.count}} app{{ result.count|pluralize }}
+                    found in {{t.count}} app{{ t.count|pluralize }}
                 </td>
                 <td style="width:300px">
-                <div class="progress">
-                    {% if result.score >= 50 %}
-                        <div class="progress-bar progress-bar-striped bg-danger" role="progressbar" style="width: {{result.score}}%;" aria-valuenow="{{result.score}}" aria-valuemin="0" aria-valuemax="100">{{result.score}}%</div>
-                    {% elif result.score >= 33 %}
-                        <div class="progress-bar progress-bar-striped bg-warning" role="progressbar" style="width: {{result.score}}%;" aria-valuenow="{{result.score}}" aria-valuemin="0" aria-valuemax="100">{{result.score}}%</div>
-                    {% else %}
-                        <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: {{result.score}}%;" aria-valuenow="{{result.score}}" aria-valuemin="0" aria-valuemax="100">{{result.score}}%</div>
-                    {% endif %}
-                </div>
-                </td></tr>
+                  <div class="progress">
+                      {% if t.score >= 50 %}
+                          <div class="progress-bar progress-bar-striped bg-danger" role="progressbar" style="width: {{t.score}}%;" aria-valuenow="{{t.score}}" aria-valuemin="0" aria-valuemax="100">{{t.score}}%</div>
+                      {% elif t.score >= 33 %}
+                          <div class="progress-bar progress-bar-striped bg-warning" role="progressbar" style="width: {{t.score}}%;" aria-valuenow="{{t.score}}" aria-valuemin="0" aria-valuemax="100">{{t.score}}%</div>
+                      {% else %}
+                          <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: {{t.score}}%;" aria-valuenow="{{t.score}}" aria-valuemin="0" aria-valuemax="100">{{t.score}}%</div>
+                      {% endif %}
+                  </div>
+                </td>
+              </tr>
             {% endfor %}
             </table>
         </div>

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -107,11 +107,11 @@ def get_stats(request):
     #     domain_results.append({'hostname':d.hostname, 'score':int(100.*d.score/sum)})
 
     tracker_query = """
-        SELECT tt.name, tt.id, COUNT(*) as c
+        SELECT tt.name, tt.id, COUNT(*) as count
         FROM reports_report_found_trackers AS ft, trackers_tracker AS tt
         WHERE tt.id = ft.tracker_id
         GROUP BY ft.tracker_id, tt.name, tt.id
-        ORDER BY c
+        ORDER BY count
         DESC LIMIT 21;
     """
     cursor.execute(tracker_query)
@@ -122,6 +122,8 @@ def get_stats(request):
     sum = len(apps)
     tracker_results = []
     for t in trackers:
-        tracker_results.append({'id': t.id, 'name': t.name, 'score': int(100.*t.c/sum), 'count': int(t.c)})
+        score = int(100.*t.count/sum)
+        count = int(t.count)
+        tracker_results.append({'id': t.id, 'name': t.name, 'score': score, 'count': count})
 
     return render(request, 'stats_details.html', {'domains': domain_results, 'trackers': tracker_results})

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -104,7 +104,15 @@ def get_stats(request):
     for d in domains:
         domain_results.append({'hostname':d.hostname, 'score':int(100.*d.score/sum)})
 
-    cursor.execute("SELECT tt.name, COUNT(*) as c FROM reports_report_found_trackers AS ft, trackers_tracker AS tt WHERE tt.id = ft.tracker_id GROUP BY ft.tracker_id, tt.name ORDER BY c DESC LIMIT 21;")
+    tracker_query = """
+        SELECT tt.name, COUNT(*) as c
+        FROM reports_report_found_trackers AS ft, trackers_tracker AS tt
+        WHERE tt.id = ft.tracker_id
+        GROUP BY ft.tracker_id, tt.name
+        ORDER BY c
+        DESC LIMIT 21;
+    """
+    cursor.execute(tracker_query)
     desc = cursor.description
     nt_result = namedtuple('Result', [col[0] for col in desc])
     trackers = [nt_result(*row) for row in cursor.fetchall()]

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -107,10 +107,10 @@ def get_stats(request):
     #     domain_results.append({'hostname':d.hostname, 'score':int(100.*d.score/sum)})
 
     tracker_query = """
-        SELECT tt.name, COUNT(*) as c
+        SELECT tt.name, tt.id, COUNT(*) as c
         FROM reports_report_found_trackers AS ft, trackers_tracker AS tt
         WHERE tt.id = ft.tracker_id
-        GROUP BY ft.tracker_id, tt.name
+        GROUP BY ft.tracker_id, tt.name, tt.id
         ORDER BY c
         DESC LIMIT 21;
     """
@@ -122,6 +122,6 @@ def get_stats(request):
     sum = len(apps)
     tracker_results = []
     for t in trackers:
-        tracker_results.append({'name': t.name, 'score': int(100.*t.c/sum), 'count': int(t.c)})
+        tracker_results.append({'id': t.id, 'name': t.name, 'score': int(100.*t.c/sum), 'count': int(t.c)})
 
     return render(request, 'stats_details.html', {'domains': domain_results, 'trackers': tracker_results})

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -86,23 +86,25 @@ def get_app_icon(request, app_id):
 def get_stats(request):
     from collections import namedtuple
     try:
-        reports = NetworkAnalysis.objects.all()
+        # reports = NetworkAnalysis.objects.all()
         apps = Application.objects.order_by('name', 'handle').distinct('name', 'handle')
-    except:
-        raise Http404("NetworkAnalysis do not exist")
+    except Exception as e:
+        raise Http404(e)
 
     cursor = connection.cursor()
-    cursor.execute("select count(hostname) as score, hostname from reports_dnsquery group by hostname having count(hostname) > 3 order by score desc;")
-    desc = cursor.description
-    nt_result = namedtuple('Result', [col[0] for col in desc])
-    domains = [nt_result(*row) for row in cursor.fetchall()]
-    sum = 0
-    for r in reports:
-        if len(r.dnsquery_set.all()) > 0:
-            sum += 1
+
+    # The part below is unused at the moment (undisplayed stats)
     domain_results = []
-    for d in domains:
-        domain_results.append({'hostname':d.hostname, 'score':int(100.*d.score/sum)})
+    # cursor.execute("select count(hostname) as score, hostname from reports_dnsquery group by hostname having count(hostname) > 3 order by score desc;")
+    # desc = cursor.description
+    # nt_result = namedtuple('Result', [col[0] for col in desc])
+    # domains = [nt_result(*row) for row in cursor.fetchall()]
+    # sum = 0
+    # for r in reports:
+    #     if len(r.dnsquery_set.all()) > 0:
+    #         sum += 1
+    # for d in domains:
+    #     domain_results.append({'hostname':d.hostname, 'score':int(100.*d.score/sum)})
 
     tracker_query = """
         SELECT tt.name, COUNT(*) as c
@@ -121,5 +123,5 @@ def get_stats(request):
     tracker_results = []
     for t in trackers:
         tracker_results.append({'name': t.name, 'score': int(100.*t.c/sum), 'count': int(t.c)})
-    
+
     return render(request, 'stats_details.html', {'domains': domain_results, 'trackers': tracker_results})

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -86,25 +86,9 @@ def get_app_icon(request, app_id):
 def get_stats(request):
     from collections import namedtuple
     try:
-        # reports = NetworkAnalysis.objects.all()
         apps = Application.objects.order_by('name', 'handle').distinct('name', 'handle')
     except Exception as e:
         raise Http404(e)
-
-    cursor = connection.cursor()
-
-    # The part below is unused at the moment (undisplayed stats)
-    domain_results = []
-    # cursor.execute("select count(hostname) as score, hostname from reports_dnsquery group by hostname having count(hostname) > 3 order by score desc;")
-    # desc = cursor.description
-    # nt_result = namedtuple('Result', [col[0] for col in desc])
-    # domains = [nt_result(*row) for row in cursor.fetchall()]
-    # sum = 0
-    # for r in reports:
-    #     if len(r.dnsquery_set.all()) > 0:
-    #         sum += 1
-    # for d in domains:
-    #     domain_results.append({'hostname':d.hostname, 'score':int(100.*d.score/sum)})
 
     tracker_query = """
         SELECT tt.name, tt.id, COUNT(*) as count
@@ -114,6 +98,7 @@ def get_stats(request):
         ORDER BY count
         DESC LIMIT 21;
     """
+    cursor = connection.cursor()
     cursor.execute(tracker_query)
     desc = cursor.description
     nt_result = namedtuple('Result', [col[0] for col in desc])
@@ -126,4 +111,4 @@ def get_stats(request):
         count = int(t.count)
         tracker_results.append({'id': t.id, 'name': t.name, 'score': score, 'count': count})
 
-    return render(request, 'stats_details.html', {'domains': domain_results, 'trackers': tracker_results})
+    return render(request, 'stats_details.html', {'trackers': tracker_results})


### PR DESCRIPTION
Adding links like https://reports.exodus-privacy.eu.org/trackers/{{ result.id }}/ to each tracker in the "Most frequent trackers" page +  a bit of reformatting / code cleaning

(Fixes #79)

Screenshot:
![image](https://user-images.githubusercontent.com/6069449/46437313-5cf03e80-c75b-11e8-8171-247172b24070.png)
