### PR TITLE
Replace old help URL by the "contribute page" URL

### DIFF
--- a/exodus/exodus/templates/base.html
+++ b/exodus/exodus/templates/base.html
@@ -36,7 +36,7 @@
             </button>
             <div class="dropdown-menu" aria-labelledby="ep_dd">
                 <a class="dropdown-item" target="_blank" href="https://exodus-privacy.eu.org">Home</a>
-                <a class="dropdown-item" target="_blank" href="https://exodus-privacy.eu.org/#help">Help us!</a>
+                <a class="dropdown-item" target="_blank" href="https://exodus-privacy.eu.org/page/contribute/">Help us!</a>
                 <a class="dropdown-item" target="_blank" href="https://github.com/Exodus-Privacy/exodus/issues">Report an issue</a>
             </div>
         </div>


### PR DESCRIPTION
Hello,

I noticed that the link on the "Help us!" button seems outdated, I replaced it with a link to the Contribute page of EP: https://exodus-privacy.eu.org/page/contribute/

![image](https://user-images.githubusercontent.com/6069449/46440362-65e50e00-c763-11e8-9881-7b6c5a88aa68.png)
