### PR TITLE
1st version of docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 /storage/
 venv/
+data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3"
+services:
+
+  objectstorage:
+    image: minio/minio:RELEASE.2018-09-25T21-34-43Z
+    volumes:
+      - ./data/objectstorage:/data
+    ports:
+      - "9000:9000"
+    environment:
+      MINIO_ACCESS_KEY: exodusexodus
+      MINIO_SECRET_KEY: exodusexodus
+    command: ["minio", "server", "/data"]
+
+  db:
+    image: postgres:9.6
+    restart: always
+    volumes:
+      - ./data/db:/var/lib/postgresql/data/pgdata
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: exodus
+      POSTGRES_PASSWORD: exodus
+      POSTGRES_DB: exodus
+      PGDATA: /var/lib/postgresql/data/pgdata
+
+  amqp:
+    image: rabbitmq:3.7-alpine
+    ports:
+      - "5672:5672"


### PR DESCRIPTION
(1st step of https://github.com/Exodus-Privacy/exodus/issues/108)

This is a 1st step toward a fully workable & easy-to-maintain dev environment in docker.

This PR includes:
- Minio (RELEASE.2018-09-25T21-34-43Z)
- Postgres 9.6
- RabbitMQ 3.7

For now, data is stored in the container. This can be fit for a dev environment (you destroy containers to reset your env in 2 docker-compose commands), but should not be used for long-term data persistence

Developer can therefore:
- Start containers using `docker-compose up` (logs in front) or `docker-compose up -d` (in background), which will expose require ports for each service locally
- [Play migrations](https://github.com/Exodus-Privacy/exodus/blob/v1/doc/install.md#step-5---create-the-db-schema) to populate the database container
- Install & run worker & web server apps locally (installing dependencies, etc...)

If you are up for it, I can package both remaining apps in docker and have them optionally deployed by docker. This can be used to offer a dev and a `quick try` setup.
If this one is merged, I will also make another PR to update documentation and give instructions for developers install.

Note: the `minio/minio` image from docker hub is not tagged as 'official'. It is an [automated build](https://hub.docker.com/r/minio/minio/) from the official repo, so I think we're still safe though :)