### PR TITLE
Improve project menu wording

### DIFF
--- a/exodus/exodus/templates/base.html
+++ b/exodus/exodus/templates/base.html
@@ -32,10 +32,10 @@
         <div class="dropdown">
             <button class="btn nav-item btn-info dropdown-toggle" type="button" id="ep_dd"
                     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Exodus Privacy
+                The project
             </button>
             <div class="dropdown-menu" aria-labelledby="ep_dd">
-                <a class="dropdown-item" target="_blank" href="https://exodus-privacy.eu.org">Home</a>
+                <a class="dropdown-item" target="_blank" href="https://exodus-privacy.eu.org">Website</a>
                 <a class="dropdown-item" target="_blank" href="https://exodus-privacy.eu.org/#help">Help us!</a>
                 <a class="dropdown-item" target="_blank" href="https://github.com/Exodus-Privacy/exodus/issues">Report an issue</a>
             </div>


### PR DESCRIPTION
5-minutes PR - I suggest making it clearer that the 1st menu is about "the Exodus Project" and not "The exodus instance you are on".

Instead of "The project", you could also have "About" for example.

![screenshot from 2018-10-05 13-10-47](https://user-images.githubusercontent.com/4201782/46532193-296afc80-c8a0-11e8-8332-33d61087f41b.png)
