### PR TITLE
Adding colors to badges on reports list page

### DIFF
--- a/exodus/exodus/templates/base.html
+++ b/exodus/exodus/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     {% load static %}
     <link rel="stylesheet" href="{% static "css/bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "css/exodus.css" %}">
 
     <script src="{% static "js/jquery-3.2.1.min.js" %}" ></script>
     <script src="{% static "js/popper.min.js" %}" ></script>

--- a/exodus/exodus/templates/base.html
+++ b/exodus/exodus/templates/base.html
@@ -10,11 +10,6 @@
     <script src="{% static "js/bootstrap.min.js" %}" ></script>
     <script src="{% static "js/handlebars.min-latest.js" %}" ></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-        body {
-            font-size: 0.9rem;
-        }
-    </style>
     <title>εxodus</title>
 </head>
 <body>

--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -6,7 +6,7 @@
     {% if reports %}
     <div class="alert bg-light">
         <div class="alert-heading">
-            <h4><span class="badge badge-info">{{ reports.count }}</span> Available report{{ reports.count|pluralize }}</h4>
+            <h4><span class="badge badge-info">{{ count }}</span> available report{{ count|pluralize }}</h4>
         </div>
         <hr>
         <table style="margin: auto; border:none" class="table table-hover table-responsive">

--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -24,13 +24,29 @@
                 </td>
                 <td class="col-md-4 text-truncate">
                     <span>
-                        <span class="badge badge-warning">{{ report.found_trackers.count }}</span>
-                        tracker{{ report.found_trackers.count|pluralize }}
+                        {% with nb_trackers=report.found_trackers.count %}
+                            {% if nb_trackers == 0 %}
+                                <span class="badge badge-success">{{ nb_trackers }}</span>
+                            {% elif nb_trackers < 5 %}
+                                <span class="badge badge-warning">{{ nb_trackers }}</span>
+                            {% else %}
+                                <span class="badge badge-danger">{{ nb_trackers }}</span>
+                            {% endif %}
+                            tracker{{ nb_trackers|pluralize }}
+                        {% endwith %}
                     </span>
                     <br>
                     <span>
-                        <span class="badge badge-warning">{{ report.application.permission_set.count }}</span>
-                        permission{{ report.application.permission_set.count|pluralize }}
+                        {% with nb_perm=report.application.permission_set.count %}
+                            {% if nb_perm == 0 %}
+                                <span class="badge badge-success">{{ nb_perm }}</span>
+                            {% elif nb_perm < 5 %}
+                                <span class="badge badge-warning">{{ nb_perm }}</span>
+                            {% else %}
+                                <span class="badge badge-danger">{{ nb_perm }}</span>
+                            {% endif %}
+                            permission{{ nb_perm|pluralize }}
+                        {% endwith %}
                     </span>
                 </td>
                 <td class="col-md-2 text-truncate">

--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -26,11 +26,11 @@
                     <span>
                         {% with nb_trackers=report.found_trackers.count %}
                             {% if nb_trackers == 0 %}
-                                <span class="badge badge-success">{{ nb_trackers }}</span>
+                                <span class="badge badge-success reports">{{ nb_trackers }}</span>
                             {% elif nb_trackers < 5 %}
-                                <span class="badge badge-warning">{{ nb_trackers }}</span>
+                                <span class="badge badge-warning reports">{{ nb_trackers }}</span>
                             {% else %}
-                                <span class="badge badge-danger">{{ nb_trackers }}</span>
+                                <span class="badge badge-danger reports">{{ nb_trackers }}</span>
                             {% endif %}
                             tracker{{ nb_trackers|pluralize }}
                         {% endwith %}
@@ -39,11 +39,11 @@
                     <span>
                         {% with nb_perm=report.application.permission_set.count %}
                             {% if nb_perm == 0 %}
-                                <span class="badge badge-success">{{ nb_perm }}</span>
+                                <span class="badge badge-success reports">{{ nb_perm }}</span>
                             {% elif nb_perm < 5 %}
-                                <span class="badge badge-warning">{{ nb_perm }}</span>
+                                <span class="badge badge-warning reports">{{ nb_perm }}</span>
                             {% else %}
-                                <span class="badge badge-danger">{{ nb_perm }}</span>
+                                <span class="badge badge-danger reports">{{ nb_perm }}</span>
                             {% endif %}
                             permission{{ nb_perm|pluralize }}
                         {% endwith %}

--- a/exodus/reports/urls.py
+++ b/exodus/reports/urls.py
@@ -4,10 +4,10 @@ from . import views
 
 app_name = 'reports'
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
+    url(r'^$', views.get_reports, name='index'),
     url(r'^(?P<report_id>[0-9]+)/$', views.detail, name='detail'),
     url(r'^(?P<app_id>[0-9]+)/icon$', views.get_app_icon, name='get_app_icon'),
     url(r'^apps/$', views.get_all_apps, name='get_all_apps'),
     url(r'^stats/$', views.get_stats, name='get_stats'),
-    url(r'^search/(?P<handle>.+)$', views.search_by_handle, name='search_by_handle'),
+    url(r'^search/(?P<handle>.+)$', views.get_reports, name='search_by_handle'),
 ]

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -17,10 +17,10 @@ def index(request):
         reports = Report.objects.order_by('-creation_date')
         paginator = Paginator(reports, settings.EX_PAGINATOR_COUNT)
         page = request.GET.get('page', 1)
-        reports = paginator.page(page)
+        reports_paged = paginator.page(page)
     except Report.DoesNotExist:
         raise Http404("reports do not exist")
-    return render(request, 'reports_list.html', {'reports': reports})
+    return render(request, 'reports_list.html', {'reports': reports_paged, 'count': reports.count()})
 
 
 def get_all_apps(request):
@@ -113,5 +113,5 @@ def get_stats(request):
     tracker_results = []
     for t in trackers:
         tracker_results.append({'name': t.name, 'score': int(100.*t.c/sum), 'count': int(t.c)})
-    
+
     return render(request, 'stats_details.html', {'domains': domain_results, 'trackers': tracker_results})

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -45,9 +45,12 @@ def get_all_apps(request):
 def search_by_handle(request, handle):
     try:
         reports = Report.objects.order_by('-creation_date').filter(application__handle = handle)
+        paginator = Paginator(reports, settings.EX_PAGINATOR_COUNT)
+        page = request.GET.get('page', 1)
+        reports_paged = paginator.page(page)
     except Report.DoesNotExist:
         raise Http404("No reports found")
-    return render(request, 'reports_list.html', {'reports': reports})
+    return render(request, 'reports_list.html', {'reports': reports_paged, 'count': reports.count()})
 
 
 def detail(request, report_id):

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -12,14 +12,16 @@ import os
 from minio import Minio
 
 
-def index(request):
+def get_reports(request, handle=None):
     try:
         reports = Report.objects.order_by('-creation_date')
+        if handle:
+            reports = reports.filter(application__handle=handle)
         paginator = Paginator(reports, settings.EX_PAGINATOR_COUNT)
         page = request.GET.get('page', 1)
         reports_paged = paginator.page(page)
     except Report.DoesNotExist:
-        raise Http404("reports do not exist")
+        raise Http404("Reports do not exist")
     return render(request, 'reports_list.html', {'reports': reports_paged, 'count': reports.count()})
 
 
@@ -40,17 +42,6 @@ def get_all_apps(request):
     except EmptyPage:
         apps = paginator.page(paginator.num_pages)
     return render(request, 'apps_list.html', {'apps': apps})
-
-
-def search_by_handle(request, handle):
-    try:
-        reports = Report.objects.order_by('-creation_date').filter(application__handle = handle)
-        paginator = Paginator(reports, settings.EX_PAGINATOR_COUNT)
-        page = request.GET.get('page', 1)
-        reports_paged = paginator.page(page)
-    except Report.DoesNotExist:
-        raise Http404("No reports found")
-    return render(request, 'reports_list.html', {'reports': reports_paged, 'count': reports.count()})
 
 
 def detail(request, report_id):

--- a/exodus/static/css/exodus.css
+++ b/exodus/static/css/exodus.css
@@ -1,0 +1,6 @@
+body {
+    font-size: 0.9rem;
+}
+.badge.reports {
+    width: 20px;
+}


### PR DESCRIPTION
Hey,

I thought it would make sense to add the same colors on the reports list page than on the report details page (see screenshots below):

![image](https://user-images.githubusercontent.com/6069449/46560322-9065d100-c8f3-11e8-9b99-f51f14b9a18a.png)
![image](https://user-images.githubusercontent.com/6069449/46560331-9b206600-c8f3-11e8-8cf0-3111d582823a.png)

I used the occasion to standardize the size of the badges (for number with 1 or 2 digits), as well as fixing a bug which was not displaying the total number of reports:
![image](https://user-images.githubusercontent.com/6069449/46560408-f3effe80-c8f3-11e8-9c2d-99102b223c69.png)
I set it back to look the way it seemed to be intended to look at first but it can be changed obviously if needed. 