### PR TITLE
API - Sorting the reports by descending application version number

### DIFF
--- a/exodus/restful_api/views.py
+++ b/exodus/restful_api/views.py
@@ -203,9 +203,9 @@ def get_all_applications(request):
 def search_strict_handle(request, handle):
     if request.method == 'GET':
         try:
-            reports = Report.objects.filter(application__handle = handle)
+            reports = Report.objects.filter(application__handle=handle).order_by('-application__version')
         except Report.DoesNotExist:
-            return JsonResponse({}, safe = True)
+            return JsonResponse({}, safe=True)
         return JsonResponse(create_reports_list(reports))
 
 
@@ -281,4 +281,3 @@ def search_strict_handle_details(request, handle):
         except Report.DoesNotExist:
             return JsonResponse({}, safe = True)
         return JsonResponse(details, safe = False)
-


### PR DESCRIPTION
Fixes #105 (reports below not being ordered by version numbers).
It could also be sorted by creation date instead, it should give the same results.

![image](https://user-images.githubusercontent.com/6069449/46660712-ec607c00-cbb7-11e8-9e3b-db2878eae7ea.png)


I am unaware whether that could have other implications.