### PR TITLE
Display number of dangerous permissions

### DIFF
--- a/exodus/reports/models.py
+++ b/exodus/reports/models.py
@@ -49,6 +49,14 @@ class Application(models.Model):
     def permissions(self):
         return self.permission_set.all().order_by('name')
 
+    def count_dangerous_permissions(self):
+        perms = self.permissions()
+        count = 0
+        for p in perms:
+            if p.severity == "dangerous":
+                count += 1
+        return count
+
     @property
     def json_signature(self):
         sign = {

--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -1,6 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
-{% load sort_dns %} 
+{% load sort_dns %}
 {% load permission_doc %}
     {% load static %}
     {% if report %}
@@ -152,11 +152,7 @@
                 </div>
                 <div class="card-body">
                     {% if report.found_trackers.all %}
-                        {% if report.found_trackers.count == 1 %}
-                            We have found <b>code signature</b> of this tracker in the application:
-                        {% else %}
-                            We have found <b>code signature</b> of these trackers in the application:
-                        {% endif %}
+                        We have found <b>code signature</b> of the following tracker{{ report.found_trackers.count|pluralize }} in the application:
                         <br>
                         <br>
                         <ul>
@@ -187,10 +183,9 @@
                 </div>
                 <div class="card-body">
                     {% if report.application.permission_set.all %}
-                        {% if report.application.permission_set.count == 1 %}
-                            We have found this permission in the application:
-                        {% else %}
-                            We have found these permissions in the application:
+                        We have found the following permission{{ report.application.permission_set.count|pluralize }} in the application:
+                        {% if report.application.count_dangerous_permissions %}
+                            (including {{ report.application.count_dangerous_permissions }} <span class="badge badge-danger">Dangerous</span>)
                         {% endif %}
                     <br>
                     <br>
@@ -238,7 +233,7 @@
                                             {% ifequal dns.is_tracker True %}
                                             <span class="badge badge-danger" data-toggle="tooltip" title="Potential tracker">⛔️</span>
                                             {% else %}
-                                                    
+
                                             {% endifequal %}
                                             </td>
                                         </tr>


### PR DESCRIPTION
Fixes #77 
Should wait for #118 to be fixed first, but good place to discuss the UI here if needed.

Screenshots below:
- with dangerous permissions
![capture du 2018-10-16 11-46-15](https://user-images.githubusercontent.com/6069449/47008042-d0ba2000-d139-11e8-9022-e048aef6a858.png)
- without dangerous permissions
![capture du 2018-10-16 11-45-58](https://user-images.githubusercontent.com/6069449/47008057-d7489780-d139-11e8-96a3-a7282700412f.png)
