### PR TITLE
remove test domains

### DIFF
--- a/exodus/exodus/core/hosts.txt
+++ b/exodus/exodus/core/hosts.txt
@@ -237,6 +237,3 @@ rts.mobula.sdk.duapps.com
 ad.prismamediadigital.com
 ad2play.ftv-publicite.fr
 adeventtracker.spotify.com
-do-not-tracker.org
-eviltracker.net
-trackersimulator.org


### PR DESCRIPTION
These 3 are junk domains from EFF's panopticlick project.  They don't do anything except test something on one privacy webpage. https://panopticlick.eff.org/