### PR TITLE
Update to exodus-core 1.0.18 & fix vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ lxml==4.3.3
 Markdown==2.6.10
 matplotlib==3.0.3
 minio==3.0.4
-mistune==0.7.4
+mistune==0.8.1
 networkx==2.3
 numpy==1.16.4
 packaging==16.8
@@ -82,7 +82,7 @@ pyperclip==1.6.0
 pyshark==0.3.7.11
 python-dateutil==2.8.0
 pytz==2017.3
-PyYAML==3.12
+PyYAML==5.1.1
 requests==2.21.0
 ruamel.yaml==0.15.35
 six==1.12.0
@@ -92,5 +92,5 @@ trollius==1.0.4
 urllib3==1.24.2
 urwid==1.3.1
 vine==1.1.4
-watchdog==0.8.3
+watchdog==0.9.0
 wcwidth==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 amqp==1.4.9
-androguard==3.1.0
+androguard==3.3.5
 anyjson==0.3.3
 argh==0.26.2
 args==0.1.0
@@ -19,6 +19,7 @@ colorama==0.4.1
 construct==2.8.16
 cryptography==2.6.1
 cssutils==1.0.2
+cycler==0.10.0
 decorator==4.4.0
 dhash==1.3
 Django~=1.11.5
@@ -27,7 +28,7 @@ django-filter==1.1.0
 djangorestframework==3.9.4
 EditorConfig==0.12.1
 enum34==1.1.6
-https://github.com/Exodus-Privacy/exodus-core/releases/download/v1.0.17/exodus_core-1.0.17.tar.gz
+https://github.com/Exodus-Privacy/exodus-core/releases/download/v1.0.18/exodus_core-1.0.18.tar.gz
 first==2.0.1
 future==0.17.1
 futures==3.1.1
@@ -46,13 +47,16 @@ jedi==0.13.3
 jellyfish==0.5.6
 jsbeautifier==1.7.5
 kaitaistruct==0.7
+kiwisolver==1.1.0
 kombu==3.0.37
 Logbook==1.4.3
 lxml==4.3.3
 Markdown==2.6.10
+matplotlib==3.0.3
 minio==3.0.4
 mistune==0.7.4
 networkx==2.3
+numpy==1.16.4
 packaging==16.8
 parso==0.4.0
 passlib==1.7.1
@@ -70,6 +74,7 @@ pyasn1==0.4.5
 pyaxmlparser==0.3.15
 pycparser==2.19
 pycryptodome==3.8.1
+pydot==1.4.1
 Pygments==2.3.1
 pyOpenSSL==17.5.0
 pyparsing==2.2.0


### PR DESCRIPTION
Updating to exodus-core 1.0.18 (which includes a new version of androguard - fixes https://github.com/Exodus-Privacy/exodus/issues/137) and fixing vulnerabilities in pyyaml & mistune

**Note that this has an impact on how the "Signed by" part looks like.**

Before:
![image](https://user-images.githubusercontent.com/6069449/60541208-56561e00-9d11-11e9-91b7-abfeb305ed5b.png)

After:
![image](https://user-images.githubusercontent.com/6069449/60541218-60781c80-9d11-11e9-8cdb-82dc8a2bc53b.png)
