### PR TITLE
[Docker] replace deprecated MAINTAINER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:9
-MAINTAINER Codimp
+LABEL maintainer="Codimp"
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Reference:
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated