### PR TITLE
Add rounded corner icon on report page

### DIFF
--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -45,9 +45,9 @@
             <div class="col">
                 <div class="alert-heading">
                     {% if report.application.name.strip %}
-                        <h2><img src="/reports/{{report.application.id}}/icon" width="60px" alt=""> <b>{{report.application.name}}</b></h2>
+                        <h2><img src="/reports/{{report.application.id}}/icon" class="rounded" width="60px" alt=""> <b>{{report.application.name}}</b></h2>
                     {% else %}
-                        <h2><img src="/reports/{{report.application.id}}/icon" width="60px" alt=""> <b>{{report.application.handle}}</b></h2>
+                        <h2><img src="/reports/{{report.application.id}}/icon" class="rounded" width="60px" alt=""> <b>{{report.application.handle}}</b></h2>
                     {% endif%}
 
                     <ul class="list-unstyled">

--- a/exodus/search/templates/search_form.html
+++ b/exodus/search/templates/search_form.html
@@ -34,7 +34,7 @@
 {{#each results}}
     <tr class="">
         <td class="col-md-2">
-            <img src="/reports/{{id}}/icon" width="50px">
+            <img class="rounded" src="/reports/{{id}}/icon" width="50px">
         </td>
         <td class="col-md-10 text-truncate text-left">
             <a href="/reports/search/{{handle}}">


### PR DESCRIPTION
Minor change to have rounded corner icons on the report page `/reports/<id>` (similar to `reports/search/<handle>`).

Before:
![image](https://user-images.githubusercontent.com/6069449/61592383-dbc34480-abd2-11e9-9941-bc2b04687bf7.png)

After:
![image](https://user-images.githubusercontent.com/6069449/61592371-c9490b00-abd2-11e9-90d4-4532e944249d.png)

