### PR TITLE
Add admin logout

### DIFF
--- a/exodus/exodus/templates/base.html
+++ b/exodus/exodus/templates/base.html
@@ -72,6 +72,7 @@
                     </a>
                     <div class="dropdown-menu" aria-labelledby="admin-dd">
                         <a class="dropdown-item" href="{% url 'analysis:index' %}">{% trans "Analyzes" %}</a>
+                        <a class="dropdown-item" href="{% url 'admin:logout' %}">{% trans "Log out" %}</a>
                     </div>
                 </li>
             </ul>


### PR DESCRIPTION
This PR adds a logout item on the admin dropdown menu 

![Screenshot_20190721_203754](https://user-images.githubusercontent.com/1569386/61595487-1095c280-abf8-11e9-86fa-c655870432fe.png)
![Screenshot_20190721_203821](https://user-images.githubusercontent.com/1569386/61595488-125f8600-abf8-11e9-8feb-088b3ec3274d.png)

Translation is already done by Django for "Log out"

Feel free to any comment :) 

I think it can close #171 