### PR TITLE
Fix issue with malformed report on admin page

### DIFF
--- a/exodus/reports/models.py
+++ b/exodus/reports/models.py
@@ -28,7 +28,11 @@ class Report(models.Model):
     class_list_file = models.CharField(max_length=200, default='')
 
     def __str__(self):
-        return self.application.handle
+        try:
+            handle = self.application.handle
+        except Exception:
+            handle = "<malformed report>"
+        return handle
 
     def trackers(self):
         return self.found_trackers.order_by('name')


### PR DESCRIPTION
When there are malformed reports in the database (i.e. reports without application), it's impossible to open the admin page of any application (ex: admin/reports/application/57/change/) due to the __str__ function of report being broken.

This change fixes it

**Before:**
![image](https://user-images.githubusercontent.com/6069449/61993150-bc5f6800-b067-11e9-9ee3-2c8ea6f264ef.png)
**After:**
![image](https://user-images.githubusercontent.com/6069449/61993153-c41f0c80-b067-11e9-956c-266b1eecd8b5.png)
