### PR TITLE
Feat/api add report update timestamp

### DIFF
--- a/exodus/restful_api/serializers.py
+++ b/exodus/restful_api/serializers.py
@@ -19,9 +19,16 @@ class ReportSerializer(serializers.ModelSerializer):
 
 
 class ApplicationSerializer(serializers.ModelSerializer):
+    class TimestampField(serializers.Field):
+        def to_representation(self, value):
+            return value.timestamp()
+
+    report_updated_at = TimestampField(source='report.updated_at')
+
     class Meta:
         model = Application
-        exclude = ('icon_path', 'report', 'version', 'version_code')
+        fields = ['id', 'handle', 'name', 'creator', 'downloads', 'app_uid',
+                  'icon_phash', 'report_updated_at']
 
 
 class TrackerSerializer(serializers.ModelSerializer):

--- a/exodus/restful_api/tests.py
+++ b/exodus/restful_api/tests.py
@@ -3,4 +3,42 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
-# Create your tests here.
+from rest_framework.test import APIClient
+
+from reports.models import Application, Report
+
+
+class RestfulApiGetAllApplicationsTests(TestCase):
+
+    def test_returns_empty_json_when_no_applications(self):
+        client = APIClient()
+        response = client.get('/api/applications')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['applications'], [])
+
+    def test_returns_applications_with_report_last_update(self):
+        report = Report()
+        report.save()
+        application = Application(
+            name='app_name',
+            handle='handle',
+            report=report
+        )
+        application.save()
+
+        client = APIClient()
+        response = client.get('/api/applications')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, application.name, 1)
+
+        report_updated_at = application.report.updated_at
+        response_application = response.json()['applications'][0]
+
+        self.assertEqual(response_application['name'], application.name)
+        self.assertEqual(response_application['handle'], application.handle)
+        self.assertEqual(
+             response_application['report_updated_at'],
+             report_updated_at.timestamp()
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,6 @@ jsbeautifier==1.7.5
 kaitaistruct==0.7
 kiwisolver==1.1.0
 kombu==3.0.37
-Logbook==1.4.3
 lxml==4.3.3
 Markdown==2.6.10
 matplotlib==3.0.3
@@ -79,7 +78,7 @@ Pygments==2.3.1
 pyOpenSSL==17.5.0
 pyparsing==2.2.0
 pyperclip==1.6.0
-pyshark==0.4.2.4
+pyshark==0.4.2.9
 python-dateutil==2.8.0
 pytz==2017.3
 PyYAML==5.1.1


### PR DESCRIPTION
Hi, 

I've added the updated at timestamp of the application's report on the ApplicationSerializer to answer this need https://github.com/Exodus-Privacy/exodus/issues/78.  It's changing /api/applications but I think it's also changing the search endpoint as it uses the same serializer.

Before: 
![Screenshot_20190825_134445](https://user-images.githubusercontent.com/1569386/63649576-92b95f80-c73f-11e9-9d2d-210563ffa985.png)
After:
![Screenshot_20190825_134636](https://user-images.githubusercontent.com/1569386/63649577-94832300-c73f-11e9-9f71-878737557fec.png)

I don't think this can break anything as it's just a new field, but we are changing the contract. Do we want to manage some versions? 

---- 

Also, I've found that as we have a 1-1 relation between Application and Report, we are getting an Application arbitrary without taking the last one (at least, not explicitly), here is the request: 
```sql
SELECT DISTINCT ON ("reports_application"."name", "reports_application"."handle"), "reports_application"."id", "reports_application"."report_id", "reports_application"."handle", "reports_application"."name", "reports_application"."creator", "reports_application"."downloads", "reports_application"."version", "reports_application"."version_code", "reports_application"."icon_path", "reports_application"."app_uid", "reports_application"."icon_phash" 
FROM "reports_application" 
ORDER BY "reports_application"."name" ASC, 
"reports_application"."handle" ASC
```

This can be changed on: 
```sql
SELECT DISTINCT ON ("reports_application"."name", "reports_application"."handle") "reports_application"."id", "reports_application"."report_id", "reports_application"."handle", "reports_application"."name", "reports_application"."creator", "reports_application"."downloads", "reports_application"."version", "reports_application"."version_code", "reports_application"."icon_path", "reports_application"."app_uid", "reports_application"."icon_phash" 
FROM "reports_application" 
INNER JOIN "reports_report" ON ("reports_application"."report_id" = "reports_report"."id") 
ORDER BY "reports_application"."name" ASC, "reports_application"."handle" ASC, "reports_report"."updated_at" DESC
``` 
But I'm not sure that is really a possible case we want to handle. I didn't succeed on reproduce this on a test. What do you think?

Feel free if there are things to change :)
