### PR TITLE
Use trigram similarity to improve application search

### DIFF
--- a/doc/install/manual.md
+++ b/doc/install/manual.md
@@ -19,6 +19,8 @@ sudo su - postgres
 psql
 CREATE USER exodus WITH PASSWORD 'exodus';
 CREATE DATABASE exodus WITH OWNER exodus;
+\c exodus
+CREATE EXTENSION pg_trgm;
 ```
 
 ## 4 - Set Python virtual environment and install dependencies

--- a/exodus/exodus/settings/base.py
+++ b/exodus/exodus/settings/base.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-from os.path import abspath, basename, dirname, join, normpath
-from sys import path
 import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -18,6 +16,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.postgres',
     'djcelery',
     'rest_framework',
     'rest_framework.authtoken'

--- a/exodus/restful_api/views.py
+++ b/exodus/restful_api/views.py
@@ -256,7 +256,7 @@ def search(request):
             if query.type == 'application':
                 try:
                     applications = Application.objects.filter(
-                        Q(handle__icontains=query.query) | Q(name__icontains=query.query)).order_by('name', 'handle').distinct('name', 'handle')[:limit]
+                        Q(handle__trigram_similar=query.query) | Q(name__trigram_similar=query.query)).order_by('name', 'handle').distinct('name', 'handle')[:limit]
                 except Application.DoesNotExist:
                     return JsonResponse([], safe=False)
                 serializer = ApplicationSerializer(applications, many=True)


### PR DESCRIPTION
Using trigram similarity to improve application search on home page

> The trigram_similar lookup allows you to perform trigram lookups, measuring the number of trigrams (three consecutive characters) shared, using a dedicated PostgreSQL extension.

See: https://docs.djangoproject.com/en/1.11/ref/contrib/postgres/lookups/#trigram-similarity

Should fix #127 