### PR TITLE
Improve dockerfile dependencies management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,17 @@
-FROM debian:9
+FROM python:3.5-stretch
 LABEL maintainer="Codimp"
 
 RUN apt-get update && \
-    apt-get install -y \
-    dexdump \
-    python3-dev \
-    python3-pip \
-    libssl-dev \
-    libffi-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    postgresql-client
+    apt-get install --no-install-recommends -y dexdump=7.0.0* postgresql-client-9.6=9.6.15* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /opt/requirements.txt
 RUN pip3 install -r /opt/requirements.txt
 
 RUN useradd -ms /bin/bash exodus
 
-RUN mkdir -p /home/exodus/.config/gplaycli && cp /usr/local/lib/python3.5/dist-packages/root/.config/gplaycli/gplaycli.conf /home/exodus/.config/gplaycli/gplaycli.conf
+RUN mkdir -p /home/exodus/.config/gplaycli && cp /usr/local/lib/python3.5/site-packages/root/.config/gplaycli/gplaycli.conf /home/exodus/.config/gplaycli/gplaycli.conf
 
 COPY ./ /home/exodus/exodus
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ function startWorker() {
 }
 
 function startFrontend() {
-	cp /usr/local/lib/python3.5/dist-packages/root/.config/gplaycli/gplaycli.conf /home/exodus/.config/gplaycli/gplaycli.conf
+	cp /usr/local/lib/python3.5/site-packages/root/.config/gplaycli/gplaycli.conf /home/exodus/.config/gplaycli/gplaycli.conf
 	cd ${EXODUS_HOME}/exodus/
 	python3 manage.py runserver --settings=exodus.settings.docker 0.0.0.0:8000
 }


### PR DESCRIPTION
Related to https://github.com/Exodus-Privacy/exodus/issues/221

In order to comply with the `--no-install-recommends` apt-get option, I first ended up adding dozens of python-related packages explicitly... Instead of doing that, which will be a nightmare to maintain, I suggest relying on the python official docker image. This will leave the hard work to the python community, on top of simplifying this Dockerfile =)

I have other ideas to improve this docker image & it's management, I'll suggest other changes (don't close the related issue just yet!) :)

ping @simpnu @codeurimpulsif 