### PR TITLE
Add hadolint linter and docker build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ script:
 
 jobs:
   include:
-    - stage: linter
+    - name: "flake8 lint"
+      stage: linter
       services: []
       before_install: []
       python: 3.6
@@ -41,3 +42,19 @@ jobs:
         - pip install flake8
       script:
         - flake8 exodus/
+
+    - name: "Dockerfile lint"
+      stage: linter
+      services: docker
+      before_install: []
+      install: []
+      script:
+        - docker run -i hadolint/hadolint < Dockerfile
+
+    - name: "Docker build test"
+      stage: Test
+      services: docker
+      before_install: []
+      install: []
+      script:
+        - docker build -t exodus .


### PR DESCRIPTION
Here is the CI part to fix https://github.com/Exodus-Privacy/exodus/issues/221:
- Run hadolint as part of the `linter` stage
- Run a `docker build` as `test` to check the build is still successful

(Need to merge [this one](https://github.com/Exodus-Privacy/exodus/pull/239) first, to pass hadolint step. [Here is](https://travis-ci.org/nautikos1235/exodus/builds/592771037) a manual test of the docker build step)