### PR TITLE
Enable PGSQL trigram support in migrations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ EXODUS_HOME="/home/exodus/exodus"
 
 function createDB() {
 	cd ${EXODUS_HOME}/exodus/
+	echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm;' | python3 manage.py dbshell --settings=exodus.settings.docker
 	python3 manage.py makemigrations --settings=exodus.settings.docker
 	python3 manage.py migrate --settings=exodus.settings.docker
 }


### PR DESCRIPTION
When running Exodus with the docker-compose setup, the search endpoint will throw due to an SQL error. This caused some head scratching for me, until I figured out that the PGSQL trigram support has to be enabled manually.

Here's the error you get:

```
ERROR:  operator does not exist: character varying % unknown at character 485
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
STATEMENT:  SELECT "reports_application"."id", "reports_application"."report_id", "reports_application"."handle", "reports_application"."name", "reports_application"."creator", "reports_application"."downloads", "reports_application"."version", "reports_application"."version_code", "reports_application"."icon_path", "reports_application"."app_uid", "reports_application"."icon_phash" FROM "reports_application" WHERE ("reports_application"."handle" = 'fr.meteo' OR "reports_application"."name" % 'fr.meteo') ORDER BY "reports_application"."name" ASC, "reports_application"."handle" ASC LIMIT 21
```

This pull request is more of a suggestion and probably needs further discussion. It's using a Django migration to enable the trigram support. It has the downside that it will prevent Exodus from running on anything other than PGSQL.

I'm also aware of #240 - if you agree with the approach I'm happy to move the migration (probably to exodus.restful_api).

Let me know what you think.