### PR TITLE
Add endpoint for latest app icon

### DIFF
--- a/exodus/exodus/templates/home.html
+++ b/exodus/exodus/templates/home.html
@@ -62,7 +62,7 @@
         <a href="{% url 'understand' %}" class="btn btn-secondary btn-block">{% trans "Let's go!" %}</a>
       </div>
     </div>
-  </div>  
+  </div>
 </div>
 
 <div class="row justify-content-center">
@@ -99,7 +99,7 @@
       <br>
       <div class="row position-relative">
         <div class="col-3 col-md-2">
-          <img class="rounded" src="/reports/{{id}}/icon" width="50px">
+          <img class="rounded" src="/reports/{{handle}}/latest/icon" width="50px">
         </div>
         <div class="col-9 col-md-10 text-truncate d-flex align-items-center position-static">
           <a href="/reports/{{handle}}/latest" class="stretched-link report-link">

--- a/exodus/reports/tests.py
+++ b/exodus/reports/tests.py
@@ -1,6 +1,52 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-# from django.test import TestCase
+from django.test import TestCase
+from unittest.mock import patch, Mock, ANY
 
-# Create your tests here.
+from reports.models import Application, Report
+
+
+class ReportsIconTests(TestCase):
+
+    def test_unknown_handle_404s(self):
+        response = self.client.get('/reports/com.example.app/latest/icon', follow=True)
+
+        self.assertEqual(response.status_code, 404)
+
+    @patch('reports.views.Minio.get_object', autospec=True, return_value=Mock(data='icon contents'))
+    def test_get_by_handle(self, get_object):
+        r = Report.objects.create()
+        Application.objects.create(report=r, handle='com.example.app', version='1')
+
+        response = self.client.get('/reports/com.example.app/latest/icon', follow=True)
+
+        self.assertTrue(get_object.called)
+        self.assertEqual(response.content, b'icon contents')
+
+    @patch('reports.views.Minio.get_object', autospec=True, return_value=Mock(data='icon contents'))
+    def test_get_by_handle_returns_latest(self, get_object):
+        r1 = Report.objects.create()
+        Application.objects.create(report=r1, handle='com.example.app', version='1', icon_path='icon1')
+        r2 = Report.objects.create()
+        Application.objects.create(report=r2, handle='com.example.app', version='2', icon_path='icon2')
+
+        response = self.client.get('/reports/com.example.app/latest/icon', follow=True)
+
+        get_object.assert_called_once_with(ANY, ANY, 'icon2')
+        self.assertEqual(response.content, b'icon contents')
+
+    def test_unknown_id_404s(self):
+        response = self.client.get('/reports/123/icon', follow=True)
+
+        self.assertEqual(response.status_code, 404)
+
+    @patch('reports.views.Minio.get_object', autospec=True, return_value=Mock(data='icon contents'))
+    def test_get_by_id(self, get_object):
+        r = Report.objects.create()
+        Application.objects.create(report=r, handle='com.example.app', version='1')
+
+        response = self.client.get('/reports/{}/icon'.format(r.pk), follow=True)
+
+        self.assertTrue(get_object.called)
+        self.assertEqual(response.content, b'icon contents')

--- a/exodus/reports/urls.py
+++ b/exodus/reports/urls.py
@@ -7,10 +7,11 @@ app_name = 'reports'
 urlpatterns = [
     url(r'^$', views.get_reports, name='index'),
     url(r'^(?P<report_id>[0-9]+)/$', views.detail, name='detail'),
-    url(r'^(?P<app_id>[0-9]+)/icon$', views.get_app_icon, name='get_app_icon'),
+    url(r'^(?P<app_id>[0-9]+)/icon$', views.get_app_icon, name='icon'),
     url(r'^apps/$', views.get_all_apps, name='get_all_apps'),
     url(r'^stats/$', RedirectView.as_view(pattern_name='trackers:get_stats', permanent=False)),
     url(r'^search/(?P<handle>.+)/$', views.get_reports, name='search_by_handle'),
     url(r'^by_tracker/$', views.by_tracker, name='by_tracker'),
     url(r'^(?P<handle>.+)/latest/$', views.detail, name='get_latest'),
+    url(r'^(?P<handle>.+)/latest/icon$', views.get_app_icon, name='icon_by_handle'),
 ]


### PR DESCRIPTION
Adds a new endpoint `/reports/<app handle>/icon` which returns the latest icon fetched for this app. The endpoint is used in the search results to fix #223.

I hope this is along the lines of what you expect. Just let me know otherwise :).

Potentially `/reports/<app handle>/latest/icon` would be a better endpoint or maybe move it into the REST API - the current endpoint is in the i18n patterns.