### PR TITLE
Ignore missing cache file during apk download

### DIFF
--- a/exodus/exodus/core/static_analysis.py
+++ b/exodus/exodus/core/static_analysis.py
@@ -117,9 +117,12 @@ def download_apk(storage, handle, tmp_dir, apk_name, apk_tmp):
                     stderr=subprocess.STDOUT,
                     timeout=240  # Timeout of 4 minutes
                 )
-                logging.info(output.decode("utf-8"))
-                if "[ERROR]" in str(output):
-                    raise Exception("Error while downloading apk file")
+                output_str = output.decode('utf-8')
+                logging.info(output_str)
+                if '[ERROR]' in output_str:
+                    filtered = output_str.replace('[ERROR] cache file does not exists or is corrupted', '')
+                    if '[ERROR]' in filtered:
+                        raise RuntimeError('Error while downloading apk file')
 
                 apk = Path(apk_tmp)
                 if apk.is_file():


### PR DESCRIPTION
I noticed that some .apk's are downloaded mulitple times during the same analysis request in my docker-compose dev setup. See below for full example logs. What happens is that GPlayCli complains about a missing cache file and Exodus picks this up as an error. This change will ignore that specific error.

I know this is quite a sensitive part of the application, so I hope I'm not missing anything :).

Before:

```
[2019-10-06 20:00:57,538: INFO/MainProcess] Received task: exodus.core.apk.start_static_analysis[40e86e74-f95f-447c-8359-031d65d82b43]
[2019-10-06 20:01:18,204: INFO/Worker-6] [INFO] GPlayCli version 3.25 [Python3.5.3]
[INFO] Configuration file is /home/exodus/.config/gplaycli/gplaycli.conf
[INFO] Device is bacon
[ERROR] cache file does not exists or is corrupted
[INFO] Retrieving token ...
[INFO] Token URL is https://matlink.fr/token/email/gsfid/bacon
[INFO] Token: pAf...
[INFO] GSFId: 374...
[INFO] Using auto retrieved token to connect to API
[INFO] 1 / 1 com.facebook.katana
[################################] 44.91MB/44.91MB - 00:00:03 10.49MB/ss
[INFO] Download complete

[2019-10-06 20:01:18,205: INFO/Worker-6] Error while downloading apk file
[2019-10-06 20:01:18,205: INFO/Worker-6] Could not download with device bacon
[2019-10-06 20:01:18,205: INFO/Worker-6] Removing cached token
[2019-10-06 20:01:36,015: INFO/Worker-6] [INFO] GPlayCli version 3.25 [Python3.5.3]
[INFO] Configuration file is /home/exodus/.config/gplaycli/gplaycli.conf
[INFO] Device is bacon
[ERROR] cache file does not exists or is corrupted
[INFO] Retrieving token ...
[INFO] Token URL is https://matlink.fr/token/email/gsfid/bacon
[INFO] Token: pAf...
[INFO] GSFId: 398...
[INFO] Using auto retrieved token to connect to API
[INFO] 1 / 1 com.facebook.katana
[################################] 44.91MB/44.91MB - 00:00:01 27.54MB/ss
[INFO] Download complete

[2019-10-06 20:01:36,016: INFO/Worker-6] Error while downloading apk file
[2019-10-06 20:01:36,016: INFO/Worker-6] Could not download with device bacon
[2019-10-06 20:01:50,861: INFO/Worker-6] [INFO] GPlayCli version 3.25 [Python3.5.3]
[INFO] Configuration file is /home/exodus/.config/gplaycli/gplaycli.conf
[INFO] Device is bacon
[INFO] Using cached token.
[INFO] Using auto retrieved token to connect to API
[INFO] 1 / 1 com.facebook.katana
[################################] 44.91MB/44.91MB - 00:00:00 00.00KB/ss
[INFO] Download complete

[2019-10-06 20:01:51,054: INFO/Worker-6] Download APK: success
```

After:

```
[2019-10-06 20:59:38,217: INFO/MainProcess] Received task: exodus.core.apk.start_static_analysis[84c6fe3a-02b0-4ce3-b67f-7f8eb3dd6138]
[2019-10-06 20:59:54,123: INFO/Worker-5] [INFO] GPlayCli version 3.25 [Python3.5.3]
[INFO] Configuration file is /home/exodus/.config/gplaycli/gplaycli.conf
[INFO] Device is bacon
[ERROR] cache file does not exists or is corrupted
[INFO] Retrieving token ...
[INFO] Token URL is https://matlink.fr/token/email/gsfid/bacon
[INFO] Token: pAf...
[INFO] GSFId: 30c...
[INFO] Using auto retrieved token to connect to API
[INFO] 1 / 1 com.facebook.katana
[################################] 44.91MB/44.91MB - 00:00:01 26.37MB/ss
[INFO] Download complete

[2019-10-06 20:59:54,314: INFO/Worker-5] Download APK: success
```