### PR TITLE
Link to sections on report page

### DIFF
--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -27,14 +27,18 @@
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-lg-4 col-12 mb-4">
       <h3>
-        <span class="badge badge-{{ tracker_class }} reports">{{ report.found_trackers.count }}</span>
-        <b>{% trans "tracker" %}{{ report.found_trackers.count | pluralize }}</b>
+        <a href="#trackers" class="section-link">
+          <span class="badge badge-{{ tracker_class }} reports">{{ report.found_trackers.count }}</span>
+          <b>{% trans "tracker" %}{{ report.found_trackers.count | pluralize }}</b>
+        </a>
       </h3>
     </div>
     <div class="col-md-8 col-lg-4 col-12 mb-4">
       <h3>
-        <span class="badge badge-{{ perm_class }} reports">{{ report.application.permission_set.count }}</span>
-        <b>{% trans "permission" %}{{ report.application.permission_set.count | pluralize }}</b>
+        <a href="#permissions" class="section-link">
+          <span class="badge badge-{{ perm_class }} reports">{{ report.application.permission_set.count }}</span>
+          <b>{% trans "permission" %}{{ report.application.permission_set.count | pluralize }}</b>
+        </a>
       </h3>
     </div>
   </div>
@@ -67,6 +71,7 @@
 
   <div class="row justify-content-sm-center mb-5">
     <div class="col-md-8 col-12">
+      <a class="anchor" id="trackers"></a>
       <h3>
         <span class="badge badge-{{ tracker_class }} reports">{{ report.found_trackers.count }}</span>
         <b>{% trans "tracker" %}{{ report.found_trackers.count | pluralize }}</b>
@@ -98,6 +103,7 @@
 
   <div class="row justify-content-sm-center mb-5">
     <div class="col-md-8 col-12">
+      <a class="anchor" id="permissions"></a>
       <h3>
         <span class="badge badge-{{ perm_class }} reports">{{ report.application.permission_set.count }}</span>
         <b>{% trans "permission" %}{{ report.application.permission_set.count | pluralize }}</b>

--- a/exodus/static/css/exodus.css
+++ b/exodus/static/css/exodus.css
@@ -37,6 +37,24 @@ a.report-link {
   color: #212529;
   font-weight: bold;
 }
+a.section-link, a.section-link:hover {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+@media (max-width: 992px) {
+  a.section-link:after {
+    content: url(/static/img/arrow-right.svg);
+    transform: rotate(90deg);
+    float: right;
+  }
+}
+a.anchor {
+  display: block;
+  position: relative;
+  top: -4.5rem;
+  visibility: hidden;
+}
 .black {
   color: #212529;
 }


### PR DESCRIPTION
This addresses #231. Frontend is definitely not my strong suit, so any comments are welcome :).

Here's what it looks like on iPhone X (according to my Firefox):

![image](https://user-images.githubusercontent.com/692141/66438787-097b9500-ea2e-11e9-8709-8c0fc88c24f8.png)

Some comments on the PR:

- Not sure if it's a good idea to mix flex and float.
- It's reusing the other arrow graphic with a transform - with this approach it's a bit tricky to add text next to the arrow.
- The breakpoint corresponds to bootstrap.
- The invisible `a` element prevents the navbar from overlapping the content.