### PR TITLE
Fix bug with paginator and unordered list

### DIFF
--- a/exodus/trackers/views.py
+++ b/exodus/trackers/views.py
@@ -34,7 +34,7 @@ def detail(request, tracker_id):
         application_ids = [i['recent_id'] for i in app_tuples]
         report_ids = Application.objects.filter(id__in=application_ids).values_list('report_id', flat=True)
         # List of only latest report for an application
-        reports_list = Report.objects.filter(id__in=report_ids, found_trackers=tracker_id)
+        reports_list = Report.objects.filter(id__in=report_ids, found_trackers=tracker_id).order_by('creation_date')
 
     except Tracker.DoesNotExist:
 


### PR DESCRIPTION
Fix a bug with pagination and unordered list.
I didn't see this bug on my local instance but it was present in production (maybe only affecting Python 3.5)