### PR TITLE
Fix search box shadow

### DIFF
--- a/exodus/static/css/exodus.css
+++ b/exodus/static/css/exodus.css
@@ -71,10 +71,10 @@ h4 {
   font-weight: bold;
 }
 input#query, input#handle {
-  border-left: none
+  border-left: none;
 }
 #query_help, #handle_help {
-  background-color: transparent
+  background-color: transparent;
 }
 ul.spaced-list > li{
   margin-bottom: 10px;

--- a/exodus/static/css/exodus.css
+++ b/exodus/static/css/exodus.css
@@ -73,6 +73,15 @@ h4 {
 input#query, input#handle {
   border-left: none;
 }
+input#query:focus, input#handle:focus {
+  box-shadow: unset;
+}
+div.input-group:focus-within * {
+  border-color: #a888b2;
+}
+div.input-group:focus-within {
+  box-shadow: 0 0 0 .2rem rgba(104,73,113,.25);
+}
 #query_help, #handle_help {
   background-color: transparent;
 }


### PR DESCRIPTION
As discussed some times ago, current box-shadow was looking strange on the home and new analysis inputs due magnifying glass looking as part of it but being excluded of the shadow.

My guess is that it's also due to the transparent background already set., it might have look less strange with the basic grey background it normally have.

Current state also had another pretty discreet issue: border was slightly changing color for purple in the input itself for right, top and bottom sides, while the three sides for the magnifying glass (left, top and bottom) were staying grey.

This patch is here to extend the box-shadow and include the magnifying glass.
Caveat: for someone watching carefully and with quick eyes, you can notice the border changes as it happens in several steps. I chose to color the whole border in purple. Other solutions could be to keep it with the light grey that's already here when it's not focused, or to completely remove the border and only keep the box-shadow rather than the border (this last option might look lighter).

Looking for your opinions now :)

EDIT: Affected pages are the homepage and the "New Analysis" ones.