### PR TITLE
Only submit analysis if an application handle is given

### DIFF
--- a/exodus/analysis_query/templates/query_submit.html
+++ b/exodus/analysis_query/templates/query_submit.html
@@ -35,7 +35,7 @@
               <small><img src="/static/img/search.svg"></small>
             </span>
           </div>
-          <input type="text" class="form-control" id="handle" name="handle" aria-describedby="handle_help">
+          <input type="text" class="form-control" id="handle" name="handle" aria-describedby="handle_help" required>
         </div>
         <p class="form-text text-muted mb-4">
           {% trans "Free applications only. Works also with the application handle." %}
@@ -84,9 +84,11 @@
 <script>
 // Spinner
 var show_spinner=function(){
-  var s = document.getElementById("loading")
-  if(s != undefined){
-    s.style.display = "block"
+  if( $("#handle").val() ) {
+    var s = document.getElementById("loading")
+    if(s != undefined){
+      s.style.display = "block"
+    }
   }
 }
 jQuery("#handle").on("input", function() {


### PR DESCRIPTION
Due to a recent change in DB, an analysis can be submitted without a handle (to allow APK submission).

The problem is that it broke the analysis validation when the `handle` form input is not filled.
I made a quick fix to check this in HTML directly. It can be bypassed but this doesn't have any real impact.
