### PR TITLE
Added Certificate details in GET /api/report/<report_id> response

### DIFF
--- a/exodus/restful_api/serializers.py
+++ b/exodus/restful_api/serializers.py
@@ -3,11 +3,20 @@ from reports.models import Report, Application, Tracker
 from .models import SearchQuery
 
 
+class CertificateSerializer(serializers.Serializer):
+    has_expired = serializers.BooleanField()
+    serial_number = serializers.CharField()
+    issuer = serializers.CharField()
+    subject = serializers.CharField()
+    fingerprint = serializers.CharField()
+
+
 class ReportInfosSerializer(serializers.Serializer):
     creation_date = serializers.DateTimeField()
     report_id = serializers.IntegerField(read_only=True)
     handle = serializers.CharField(max_length=500)
     apk_dl_link = serializers.CharField(max_length=500)
+    certificate = CertificateSerializer(required=False)
 
 
 class ReportSerializer(serializers.ModelSerializer):

--- a/exodus/restful_api/views.py
+++ b/exodus/restful_api/views.py
@@ -13,7 +13,7 @@ from rest_framework.decorators import api_view, permission_classes, authenticati
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 
-from reports.models import Application, Report
+from reports.models import Application, Report, Certificate
 from trackers.models import Tracker
 from restful_api.serializers import ApplicationSerializer, TrackerSerializer,\
     ReportInfosSerializer, ReportSerializer, SearchQuerySerializer,\
@@ -31,10 +31,16 @@ def get_report_infos(request, r_id):
         except Report.DoesNotExist:
             raise Http404('No report found')
 
+        certificate = None
+        if hasattr(report.application, 'apk'):
+            certificates = Certificate.objects.filter(apk=report.application.apk)
+            certificate = certificates.first()
+
         obj = {
             'creation_date': report.creation_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             'report_id': report.id,
             'handle': report.application.handle,
+            'certificate': certificate,
             'apk_dl_link': '',
         }
         if request.user.is_staff:


### PR DESCRIPTION
This PR allows one to fetch certificate details for a given report:


```
GET /api/report/111231/
```

```json
{
  "creation_date": "2020-01-27T16:37:13.626092Z",
  "report_id": 1,
  "handle": "com.spotify.music",
  "apk_dl_link": "",
  "certificate": {
    "has_expired": false,
    "serial_number": "1707787441", 
    "issuer": "Common Name: Spotify, Organizational Unit: Android, Organization: Spotify, Locality: Stockholm, State/Province: Stockholm, Country: SE",
    "subject": "Common Name: Spotify, Organizational Unit: Android, Organization: Spotify, Locality: Stockholm, State/Province: Stockholm, Country: SE", 
    "fingerprint": "d6a6dced4a85f24204bf9505ccc1fce114cadb32"
 }
}
```
