### PR TITLE
Add new open API endpoint to get latest report id & date

### DIFF
--- a/exodus/analysis_query/templates/query_submit.html
+++ b/exodus/analysis_query/templates/query_submit.html
@@ -92,27 +92,25 @@ var show_spinner=function(){
   }
 }
 
-// TODO: Use an API endpoint not blocked and which returns the latest report
 var check_existing_report=function(handle){
   const regex_pk = /^((?:\w+\.)+\w+)$/gmi;
   if(regex_pk.test(handle)){
-      jQuery.get("/api/search/"+handle, function(rq){
-          if(rq[handle]){
+      jQuery.get("/api/search/"+handle+"/latest", function(rq){
+          if(rq.id){
               jQuery("#reports").html('')
               jQuery("#reports").show()
 
               var p = document.createElement('p')
               var name = handle
-              if(rq[handle].name != '') {
-                  name = rq[handle].name
+              if(rq.name != '') {
+                  name = rq.name
               }
               p.innerHTML = "<b>{% trans  'This application has already been analyzed!' %}</b>"
               jQuery("#reports").append(p)
 
-              var latest_report = rq[handle].reports.shift()
-              var report_date = latest_report.creation_date.substring(0, 10)
+              var report_date = rq.creation_date.substring(0, 10)
               var p2 = document.createElement('p')
-              p2.innerHTML = name + ' - {% trans "analyzed on" %} '+report_date+' - <a href="/reports/'+latest_report.id+'/">{% trans "Go to the latest report" %}</a>'
+              p2.innerHTML = name + ' - {% trans "analyzed on" %} '+report_date+' - <a href="/reports/'+rq.id+'/">{% trans "Go to the latest report" %}</a>'
               jQuery("#reports").append(p2)
 
               var p3 = document.createElement('p')
@@ -133,12 +131,12 @@ jQuery("#handle").on("input", function() {
         while (match != null) {
           if(match[1]){
             jQuery(this).val(match[1])
-            // check_existing_report(match[1])
+            check_existing_report(match[1])
           }
           return
         }
     } else {
-      // check_existing_report(handle)
+      check_existing_report(handle)
     }
 });
 

--- a/exodus/restful_api/urls.py
+++ b/exodus/restful_api/urls.py
@@ -12,5 +12,6 @@ urlpatterns = [
     path('get_auth_token/', rest_framework_views.obtain_auth_token, name='get_auth_token'),
     path('search/<handle>/details', views.search_strict_handle_details, name='search_strict_handle_details'),
     path('search/<handle>', views.search_strict_handle, name='search_strict_handle'),
+    path('search/<handle>/latest', views.search_latest_report, name='search_latest_report'),
     path('search', views.search, name='search'),
 ]

--- a/exodus/restful_api/views.py
+++ b/exodus/restful_api/views.py
@@ -173,6 +173,26 @@ def search_strict_handle(request, handle):
 
 @csrf_exempt
 @api_view(['GET'])
+@authentication_classes(())
+@permission_classes(())
+def search_latest_report(request, handle):
+    if request.method == 'GET':
+        try:
+            report = Report.objects.filter(application__handle=handle).order_by('-creation_date').first()
+            if not report:
+                raise Report.DoesNotExist
+        except Report.DoesNotExist:
+            return JsonResponse({}, safe=True)
+        obj = {
+            'id': report.id,
+            'name': report.application.name,
+            'creation_date': report.creation_date
+        }
+        return JsonResponse(obj)
+
+
+@csrf_exempt
+@api_view(['GET'])
 @authentication_classes((TokenAuthentication,))
 @permission_classes((IsAuthenticated,))
 def get_report_details(request, r_id):


### PR DESCRIPTION
Added a new **open** API endpoint to get the latest report for a given handle.
Only returns the id, name and creation date.

Fixes #317 

![image](https://user-images.githubusercontent.com/6069449/74610297-40576b00-50f2-11ea-8d2f-35eeb9981e9e.png)
