### PR TITLE
Remove XFrameOptionsMiddleware

### DIFF
--- a/exodus/exodus/settings/base.py
+++ b/exodus/exodus/settings/base.py
@@ -46,7 +46,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
 ROOT_URLCONF = 'exodus.urls'


### PR DESCRIPTION
Currently the `x-frame-options` header is set by both the exodus django app and nginx:
![image](https://user-images.githubusercontent.com/6069449/75481130-d87f0b00-59a2-11ea-9469-c1a1adddac23.png)

This removes it from django to keep nginx dealing with security headers.