### PR TITLE
Paste Google play URL into search field

### DIFF
--- a/exodus/web/templates/base/home.html
+++ b/exodus/web/templates/base/home.html
@@ -176,6 +176,17 @@
     }
     const query = jQuery.trim(jQuery(this).val())
     if(query.length >= 5) {
+      // Extract handle from Google Play url
+      const regex = /id=((?:\w+\.)+\w+)/gmi;
+      if(query.startsWith("https://play.google.com")){
+          var match = regex.exec(query)
+          while (match != null) {
+            if(match[1]){
+              jQuery(this).val(match[1])
+            }
+            return
+          }
+      }
       search_timer = setTimeout(function(){ get_results(query, 20); }, 200);
     }
     if(query == '') {


### PR DESCRIPTION
Adds the possibility to paste Google Play URL into the search field of the home page to directly get the results, for instance pasting `https://play.google.com/store/apps/details?id=org.eu.exodus_privacy.exodusprivacy` if you want to search for reports for the exodus app