### PR TITLE
Improve Docker setup for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,15 @@ RUN apt-get update && \
 COPY ./requirements.txt /opt/requirements.txt
 RUN pip3 install -r /opt/requirements.txt
 
-RUN useradd -ms /bin/bash exodus
-
 RUN mkdir -p /home/exodus/.config/gplaycli
 COPY ./docker.gplaycli.* /home/exodus/.config/gplaycli/
 RUN patch /usr/local/lib/python3.7/site-packages/gplaycli/gplaycli.py /home/exodus/.config/gplaycli/docker.gplaycli.patch
 
-COPY ./ /home/exodus/exodus
+COPY ./ /exodus
+
+WORKDIR /exodus/exodus
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
-RUN chown -R exodus:exodus /home/exodus
-USER exodus
-WORKDIR /home/exodus/exodus/exodus
 
 CMD ["/entrypoint.sh", "init"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: ./
     container_name: exodus
     image: exodus
+    volumes:
+      - ./exodus:/exodus/exodus:rw,cached
     depends_on:
       - minio
       - db

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ function createUser() {
 
 function startWorker() {
 	cd ${EXODUS_HOME}/exodus/
-	export DJANGO_SETTINGS_MODULE=exodus.settings.docker; celery worker -A exodus.core -l info
+	export DJANGO_SETTINGS_MODULE=exodus.settings.docker; export C_FORCE_ROOT=1; celery worker -A exodus.core -l info
 }
 
 function startFrontend() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXODUS_HOME="/home/exodus/exodus"
+EXODUS_HOME="/exodus"
 
 function createDB() {
 	cd ${EXODUS_HOME}/exodus/


### PR DESCRIPTION
For the Docker setup to be useful when developing, a shared volume needs to be used in Docker Compose. With it, a change in the code will be be reflected immediately in the application without rebuilding the container.

However, a root user needs to be used in the container for creating or modifying files in the shared volume (for instance when updating the translation files).
It's because when you use a shared volume, the volume is mounted inside the container with the same UID/GUID as the host. And since it's different from the UID/GUID of the user inside the container, the permissions are not correct. It's a troublesome issue with Docker, and there is no perfect way to solve it.

Using a non-root user will be preferable if the Dockerfile is used in a production environment though. In this case, having two Dockerfiles, one for the dev and one for the prod, could be a solution.