### PR TITLE
Add short option for API endpoint 'applications'

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -41,33 +41,67 @@ Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b
 
 ## Get all analyzed applications
 
+### With full details
+
 `GET` https://reports.exodus-privacy.eu.org/api/applications returns `JSON`
 ```
 {
   "applications": [
     {
+      "id": 1,
       "handle": "com.johnson.nett",
       "name": "Calendrier des r\\u00e8gles NETT \\u00ae",
       "creator": "JOHNSON & JOHNSON SANTE BEAUTE FRANCE",
       "downloads": "50,000+ downloads",
       "app_uid": "C585E0D6274EDA2FA159542E305D2C61963BA8CC",
-      "icon_phash": "103278408296944969572136665785814778239"
+      "icon_phash": "103278408296944969572136665785814778239",
+      "report_updated_at": 1568136675.813601
     },
     {
+      "id": 2,
       "handle": "cdiscount.mobile",
       "name": "Cdiscount : N'\\u00e9conomisez pas votre plaisir",
       "creator": "Cdiscount",
       "downloads": "1,000,000+ downloads",
       "app_uid": "9F4CCA45C68B96EACD9D012F0902F406126FF660",
-      "icon_phash": "320076679825009360506916699520458898952"
+      "icon_phash": "320076679825009360506916699520458898952",
+      "report_updated_at": 1575063216.526062
     },
     {
+      "id": 3,
       "handle": "ch.hug_ge.emoteo",
       "name": "Emoteo",
       "creator": "HUG H\\u00f4pitaux universitaires de Gen\\u00e8ve",
       "downloads": "1,000+ downloads",
       "app_uid": "22ECA4EC976CC4FB11C6A0A24B2A90769E5F1A64",
-      "icon_phash": "216013393868481183094163051465356731136"
+      "icon_phash": "216013393868481183094163051465356731136",
+      "report_updated_at": 1587278984.683278
+    },
+    [edited]
+  ]
+}
+```
+
+### With limited details
+
+`GET` https://reports.exodus-privacy.eu.org/api/applications?option=short returns `JSON`
+```
+{
+  "applications": [
+    {
+      "id": 1,
+      "handle": "com.johnson.nett",
+      "app_uid": "C585E0D6274EDA2FA159542E305D2C61963BA8CC"
+    },
+    {
+      "id": 2,
+      "handle": "cdiscount.mobile",
+      "app_uid": "9F4CCA45C68B96EACD9D012F0902F406126FF660"
+    },
+    {
+      "id": 3,
+      "handle": "ch.hug_ge.emoteo",
+      "app_uid": "22ECA4EC976CC4FB11C6A0A24B2A90769E5F1A64"
     },
     [edited]
   ]

--- a/exodus/restful_api/serializers.py
+++ b/exodus/restful_api/serializers.py
@@ -26,6 +26,12 @@ class ReportSerializer(serializers.ModelSerializer):
         depth = 1
 
 
+class ApplicationShortSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Application
+        fields = ['id', 'handle', 'app_uid']
+
+
 class ApplicationSerializer(serializers.ModelSerializer):
     class TimestampField(serializers.Field):
         def to_representation(self, value):

--- a/exodus/restful_api/tests.py
+++ b/exodus/restful_api/tests.py
@@ -46,7 +46,7 @@ class RestfulApiApplicationTests(APITestCase):
         expected_json = {
             'applications': [
                 {
-                    'id': application.id,
+                    "id": application.id,
                     "handle": application.handle,
                     "name": application.name,
                     "creator": "",
@@ -59,6 +59,30 @@ class RestfulApiApplicationTests(APITestCase):
         }
 
         response = self.client.get(self.PATH)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected_json)
+
+    def test_returns_applications_with_option_short(self):
+        self._force_authentication()
+        report = Report.objects.create(id=1234)
+        application = Application.objects.create(
+            name='app_name',
+            handle='handle',
+            report=report
+        )
+
+        expected_json = {
+            'applications': [
+                {
+                    "id": application.id,
+                    "handle": application.handle,
+                    "app_uid": "",
+                },
+            ]
+        }
+
+        response = self.client.get(self.PATH + '?option=short')
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected_json)

--- a/exodus/restful_api/views.py
+++ b/exodus/restful_api/views.py
@@ -17,7 +17,7 @@ from reports.models import Application, Report, Certificate
 from trackers.models import Tracker
 from restful_api.serializers import ApplicationSerializer, TrackerSerializer,\
     ReportInfosSerializer, ReportSerializer, SearchQuerySerializer,\
-    SearchApplicationSerializer
+    SearchApplicationSerializer, ApplicationShortSerializer
 
 
 @csrf_exempt
@@ -152,7 +152,10 @@ def get_all_applications(request):
     if request.method == 'GET':
         try:
             applications = Application.objects.order_by('name', 'handle').distinct('name', 'handle')
-            serializer = ApplicationSerializer(applications, many=True)
+            if request.GET.get('option', 'full') == 'short':
+                serializer = ApplicationShortSerializer(applications, many=True)
+            else:
+                serializer = ApplicationSerializer(applications, many=True)
             return JsonResponse({'applications': serializer.data}, safe=False)
         except Application.DoesNotExist:
             return JsonResponse({}, safe=True)


### PR DESCRIPTION
Simple solution to add new option for API endpoint 'applications', mostly for the exodus Android application

cc @Schoumi @codeurimpulsif 