### PR TITLE
Precise that tracker stats are only for GPlay

### DIFF
--- a/exodus/trackers/tasks.py
+++ b/exodus/trackers/tasks.py
@@ -68,7 +68,8 @@ def calculate_trackers_statistics():
     ev = EventGroup()
 
     trackers = Tracker.objects.order_by('name')
-    application_report_id_map = Report.objects.values('application__handle').annotate(recent_id=Max('id'))
+    google_app_reports = Report.objects.filter(application__source='google')
+    application_report_id_map = google_app_reports.values('application__handle').annotate(recent_id=Max('id'))
     report_ids = [k['recent_id'] for k in application_report_id_map]
 
     reports_number = Report.objects.filter(id__in=report_ids).count()

--- a/exodus/trackers/templates/stats_details.html
+++ b/exodus/trackers/templates/stats_details.html
@@ -7,7 +7,13 @@
     <div class="col-lg-8">
       <div style="text-align:center">
         <h1 class="main-title">{% trans "Statistics" %}</h1>
-        <h4>{% trans "Most frequent trackers" %}</h4>
+        <span class="d-none d-md-block">
+          <h4>{% trans "Most frequent trackers" %} - Google Play</h4>
+        </span>
+        <span class="d-md-none">
+          <h4>{% trans "Most frequent trackers" %}</h4>
+          <h5>(Google Play)</h5>
+        </span>
       </div>
       <hr>
       <table style="margin: auto">

--- a/exodus/trackers/tests.py
+++ b/exodus/trackers/tests.py
@@ -19,6 +19,7 @@ class TrackersStatsViewTests(TestCase):
         report = Report.objects.create()
         Application.objects.create(
             handle="apple_sauce",
+            source="google",
             report=report
         )
 
@@ -32,6 +33,7 @@ class TrackersStatsViewTests(TestCase):
         report = Report.objects.create()
         Application.objects.create(
             handle="apple_sauce",
+            source="google",
             report=report
         )
         calculate_trackers_statistics()
@@ -53,6 +55,7 @@ class TrackersStatsViewTests(TestCase):
         report = Report.objects.create()
         Application.objects.create(
             handle="apple_sauce",
+            source="google",
             report=report
         )
         report.found_trackers.set([tracker.id])
@@ -81,18 +84,21 @@ class TrackersStatsViewTests(TestCase):
         report1.found_trackers.set([tracker2.id])
         Application.objects.create(
             handle=application_handle,
+            source="google",
             report=report1
         )
         report2 = Report.objects.create()
         report2.found_trackers.set([])
         Application.objects.create(
             handle=application_handle,
+            source="google",
             report=report2
         )
         report3 = Report.objects.create()
         report3.found_trackers.set([tracker1.id, tracker2.id])
         Application.objects.create(
             handle=application_handle,
+            source="google",
             report=report3
         )
         calculate_trackers_statistics()
@@ -126,18 +132,21 @@ class TrackersStatsViewTests(TestCase):
         report1.found_trackers.set([tracker2.id])
         Application.objects.create(
             handle=application_handle1,
+            source="google",
             report=report1
         )
         report2 = Report.objects.create()
         report2.found_trackers.set([])
         Application.objects.create(
             handle=application_handle2,
+            source="google",
             report=report2
         )
         report3 = Report.objects.create()
         report3.found_trackers.set([tracker1.id, tracker2.id])
         Application.objects.create(
             handle=application_handle2,
+            source="google",
             report=report3
         )
         calculate_trackers_statistics()
@@ -168,6 +177,7 @@ class TrackersStatsViewTests(TestCase):
         report = Report.objects.create()
         Application.objects.create(
             handle="apple_sauce",
+            source="google",
             report=report
         )
         report.found_trackers.set([t.id for t in first_trackers])


### PR DESCRIPTION
Currently statistics calculation doesn't handle well the different source and will just take the latest report, disregarding of the source. 
This change makes sure it only uses Google Play app reports for the time being

**Screenshots:**
![image](https://user-images.githubusercontent.com/6069449/87089061-1d129100-c236-11ea-90cd-d10919e51286.png)

![image](https://user-images.githubusercontent.com/6069449/87089097-2996e980-c236-11ea-9854-59e055491770.png)
