### PR TITLE
 Replace buster by buster-slim in Docker image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.7-buster
+FROM python:3.7-slim-buster
 LABEL maintainer="Codimp"
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y dexdump=8.1.0* postgresql-client-11=11* gettext=0.* && \
+    apt-get install --no-install-recommends -y dexdump=8.1.0* postgresql-client-11=11* libpq-dev=11.* gcc=4:8.3.* musl-dev=1.1.* libc6-dev=2.* gettext=0.* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM python:3.7-slim-buster
 LABEL maintainer="Codimp"
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y dexdump=8.1.0* postgresql-client-11=11* libpq-dev=11.* gcc=4:8.3.* musl-dev=1.1.* libc6-dev=2.* gettext=0.* && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  dexdump=8.1.0* \
+  postgresql-client-11=11* \
+  libpq-dev=11.* \
+  gcc=4:8.3.* \
+  musl-dev=1.1.* \
+  libc6-dev=2.* \
+  gettext=0.* \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /opt/requirements.txt
 RUN pip3 install -r /opt/requirements.txt


### PR DESCRIPTION
Changed base image in Dockerfile to slim image in order to gain space

Before: 1.24GB
After: 628MB

Used the occasion to change the multi-line command in order to improve readability (based on https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#sort-multi-line-arguments)