### PR TITLE
Fix auto_update_trackers by just looking for id 

### DIFF
--- a/exodus/trackers/tasks.py
+++ b/exodus/trackers/tasks.py
@@ -34,29 +34,33 @@ def auto_update_trackers():
 
     updated_code_signatures = 0
 
-    for _, tracker in trackers['trackers'].items():
-        obj, created = Tracker.objects.update_or_create(
-            id=tracker['id'],
-            name=tracker['name'],
-            website=tracker['website'],
-            defaults={
-                'description': tracker['description'],
-                'creation_date': tracker['creation_date'],
-                'network_signature': tracker['network_signature']
-            }
-        )
-        if obj.code_signature != tracker['code_signature']:
-            obj.code_signature = tracker['code_signature']
-            obj.save()
-            updated_code_signatures += 1
+    try:
+        for _, tracker in trackers['trackers'].items():
+            obj, created = Tracker.objects.update_or_create(
+                id=tracker['id'],
+                name=tracker['name'],
+                website=tracker['website'],
+                defaults={
+                    'description': tracker['description'],
+                    'creation_date': tracker['creation_date'],
+                    'network_signature': tracker['network_signature']
+                }
+            )
+            if obj.code_signature != tracker['code_signature']:
+                obj.code_signature = tracker['code_signature']
+                obj.save()
+                updated_code_signatures += 1
 
-        if created:
-            logger.info('Tracker {} has been added.'.format(tracker['name']))
-        else:
-            logger.info('Tracker {} has been updated.'.format(tracker['name']))
+            if created:
+                ev.info('Tracker {} has been added.'.format(tracker['name']))
+            else:
+                ev.info('Tracker {} has been updated.'.format(tracker['name']))
 
-    if updated_code_signatures > 0:
-        recompute_all_reports.delay()
+        if updated_code_signatures > 0:
+            recompute_all_reports.delay()
+    except Exception as e:
+        ev.error(e, initiator=__name__)
+        return
 
     ev.info('{} code signatures updated.'.format(updated_code_signatures), initiator=__name__)
 

--- a/exodus/trackers/tasks.py
+++ b/exodus/trackers/tasks.py
@@ -38,9 +38,9 @@ def auto_update_trackers():
         for _, tracker in trackers['trackers'].items():
             obj, created = Tracker.objects.update_or_create(
                 id=tracker['id'],
-                name=tracker['name'],
-                website=tracker['website'],
                 defaults={
+                    'name': tracker['name'],
+                    'website': tracker['website'],
                     'description': tracker['description'],
                     'creation_date': tracker['creation_date'],
                     'network_signature': tracker['network_signature']


### PR DESCRIPTION
Just found out that the trackers auto update feature was recently broken.
I think it comes from the fact that we changed the name of some trackers and this function doesn't handle it well.

What I did: 
* Catch error and display it in Event logs (324b3dcbb5b342846372f48fab1284ee6dfde249)
* Display logs of tracker updates in Event logs (324b3dcbb5b342846372f48fab1284ee6dfde249)
* Only use tracker id to update them instead of combination of id, name & website (bf7e65b6930893d2a5cb03e0bcebd64dd8406994)

Note: check the 2 commits separately for more convenience :)