### PR TITLE
feat: Add API key creation page

### DIFF
--- a/exodus/trackers/templates/new_api_key.html
+++ b/exodus/trackers/templates/new_api_key.html
@@ -1,0 +1,48 @@
+{% extends "base/base.html"%}
+{% load i18n %}
+{% block content %}
+<div class="row justify-content-md-center">
+  <div class="col col-lg-10 col-centered">
+    {% if request.user.is_superuser %}
+    <h2>New API key</h2>
+    {% if api_key %}
+    <div class="alert alert-success">
+      <strong>Success!</strong> New API key: {{ api_key }}
+    </div>
+    {% endif %}
+    {% if error %}
+    <div class="alert alert-danger">
+      <strong>Error:</strong> {{ error }}
+    </div>
+    {% endif %}
+    <form method="post">
+      {% csrf_token %}
+      <div class="form-group">
+        <label for="username">Username</label>
+        <input type="type" class="form-control" name="username" id="username" placeholder="Enter username" required>
+      </div>
+      <div class="form-group">
+        <label for="email">Email address</label>
+        <input type="email" class="form-control" name="email" id="email" placeholder="Enter email" required>
+      </div>
+      <div class="form-group">
+        <label for="first-name">First name</label>
+        <input type="type" class="form-control" name="first-name" id="first-name" placeholder="Enter first name" required>
+      </div>
+      <div class="form-group">
+        <label for="last-name">Last name</label>
+        <input type="type" class="form-control" name="last-name" id="last-name" placeholder="Enter last name" required>
+      </div>
+      <button type="submit" class="btn btn-primary mt-2">Create new API key</button>
+    </form>
+    <div class="mt-4">
+      <a target="_blank" href="{% url 'admin:authtoken_token_changelist' %}">See existing API keys</a>
+    </div>
+    {% else %}
+    <div class="alert alert-danger small">
+      <strong>{% trans "You need to be registered" %}.</strong>
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/exodus/trackers/urls.py
+++ b/exodus/trackers/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('stats/', views.get_stats, name='get_stats'),
     path('graph/', views.graph, name='graph'),
     path('details/', views.TrackersListView.as_view(), name='all_details'),
+    path('api_key/', views.new_api_key, name='new_api_key'),
 ]

--- a/exodus/web/templates/base/base.html
+++ b/exodus/web/templates/base/base.html
@@ -61,6 +61,7 @@
               <a class="dropdown-item" href="{% url 'admin:index' %}">{% trans "Index" %}</a>
               <a class="dropdown-item" href="{% url 'analysis:index' %}">{% trans "Analyzes" %}</a>
               <a class="dropdown-item" href="{% url 'trackers:all_details' %}">{% trans "Trackers" %}</a>
+              <a class="dropdown-item" href="{% url 'trackers:new_api_key' %}">New API key</a>
               <a class="dropdown-item text-danger" href="{% url 'admin:logout' %}">{% trans "Log out" %}</a>
             </div>
           </li>


### PR DESCRIPTION
## New feature

* New page to create an API key easily
* Asks the following input: username, email, first name, last name
* Generates a random password for the account (as it is never used)
* Provides a link for the existing API keys if needed
* Note: this is a first ugly implementation, could be way better and more thoroughly tested, but it works :shrug: 

## Screenshots

* Link to the new page in the Admin dropdown
![image](https://user-images.githubusercontent.com/6069449/128185333-0dc29de4-e438-4c64-b084-e848fc772cc9.png)

* New page
![image](https://user-images.githubusercontent.com/6069449/128185457-1eb31061-7d68-48c0-8dbb-99d133849792.png)

* Once the API key is created
![image](https://user-images.githubusercontent.com/6069449/128185541-3cb26cfc-0923-4a12-b268-efeaf89179d4.png)

