### PR TITLE
fix: Downgrade urllib3 to fix issue with gpapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ requests==2.26.0
 six==1.15.0
 sqlparse==0.3.0
 traitlets==4.3.2
-urllib3==1.26.6
+urllib3==1.24.2
 vine==1.3.0
 wcwidth==0.1.7
 zipp==0.6.0


### PR DESCRIPTION
While https://github.com/NoMore201/googleplay-api/pull/145 is not merged to gpapi package, we need to downgrade the version of urllib3 to prevent this bug: https://github.com/matlink/gplaycli/issues/260