### PR TITLE
fix: Prevents overwriting request variable in analysis page

### DIFF
--- a/exodus/analysis_query/templates/query_wait.html
+++ b/exodus/analysis_query/templates/query_wait.html
@@ -15,7 +15,7 @@
   <div class="col-md-8 col-12 col-centered mb-4">
     <div id="loading" class="text-center" style="">
       <div id="description" class="alert alert-info" role="alert">
-        {% trans request.description %}
+        {% trans analysis.description %}
       </div>
       <p id="completed" style="display:none" class="text-center mt-5">
         <img src="{% static 'img/analysis_completed.png' %}" width="120">
@@ -50,7 +50,7 @@
   const refresh = function(){
     console.log("Refresh")
 
-    jQuery.get("/analysis/{{request.id}}/json", function(rq){
+    jQuery.get("/analysis/{{analysis.id}}/json", function(rq){
       jQuery("#description").removeClass("alert-danger alert-info")
       jQuery("#description").html(rq.description)
       if(rq.in_error){

--- a/exodus/analysis_query/views.py
+++ b/exodus/analysis_query/views.py
@@ -71,10 +71,10 @@ class AnalysisRequestView(FormView):
 
 def wait(request, r_id):
     try:
-        r = AnalysisRequest.objects.get(pk=r_id)
+        analysis = AnalysisRequest.objects.get(pk=r_id)
     except AnalysisRequest.DoesNotExist:
         raise Http404(_("AnalysisRequest does not exist"))
-    return render(request, 'query_wait.html', {'request': r})
+    return render(request, 'query_wait.html', {'analysis': analysis})
 
 
 def json(request, r_id):


### PR DESCRIPTION
## Context

The Django variable `request` was overwritten in `exodus/analysis_query/views.py` meaning that we did not have access to information such as whether the user is admin or not.

That explains the missing "Admin" menu on analysis page.
This PR fixes it, by renaming `request` to `analysis`.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6069449/137517067-ba79a6e5-6d7c-4e3a-b444-23569a395b3c.png)

### After

![image](https://user-images.githubusercontent.com/6069449/137517114-5fbb4536-a262-41ce-95c7-8729f1212621.png)
