### PR TITLE
Fix docker-compose uid and documentation

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -40,22 +40,16 @@ GOOGLE_ACCOUNT_PASSWORD = "<a valid google password>"
 echo uid=$(id -u) > .env
 docker-compose up -d
 # Once exodus started, you can check its logs
-docker-compose logs -f exodus-worker
+docker-compose logs -f exodus-front
 ```
 
-When everything is up (Docker logs `Exodus DB is ready.`), launch the worker:
-
-```bash
-docker-compose exec exodus-worker /entrypoint.sh start-worker
-```
-
-Then, you may have to force a first download of the F-Droid index:
+When everything is up (Docker logs `Exodus DB is ready.`), you may have to force a first download of the F-Droid index:
 
 ```bash
 docker-compose exec exodus-worker /entrypoint.sh refresh-fdroid-index
 ```
 
-**The worker must be running** (previous command) to do this.
+**The worker must be running** to do this.
 
 The exodus container automatically:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
             - exodus
     ports:
       - "80:8000"
-    user: ${uid?'echo uid=$(id -u) >> .env'}
+    user: ${uid}
     volumes:
       - ./exodus:/exodus/exodus:rw,cached
 
@@ -61,7 +61,7 @@ services:
       backend:
         aliases:
             - exodus-worker
-    user: ${uid?'echo uid=$(id -u) >> .env'}
+    user: ${uid}
     volumes:
       - ./exodus:/exodus/exodus:rw,cached
 


### PR DESCRIPTION
## Goals

- Fix uid usage with docker-compose V2 (already work with V1)
- Fix documentation since https://github.com/Exodus-Privacy/exodus/pull/435

## Informations

`${uid?'echo uid=$(id -u) >> .env'}` don't work with docker-compose V2, `${uid}` works for both V1 and V2