### PR TITLE
fix: Fix getting icon in refresh report scripts

### DIFF
--- a/exodus/reports/management/commands/refreshapksignature.py
+++ b/exodus/reports/management/commands/refreshapksignature.py
@@ -51,7 +51,8 @@ class Command(BaseCommand):
                 except ResponseError:
                     raise CommandError('Unable to get APK')
                 static_analysis = StaticAnalysis(apk_path=apk_tmp)
-                icon_phash = static_analysis.get_icon_and_phash(storage_helper, icon_name)
+                source = report.application.source
+                icon_phash = static_analysis.get_icon_and_phash(storage_helper, icon_name, source)
                 if icon_phash:
                     report.application.icon_path = icon_name
                     report.application.save()

--- a/exodus/reports/management/commands/refreshstaticanalysis.py
+++ b/exodus/reports/management/commands/refreshstaticanalysis.py
@@ -90,7 +90,8 @@ class Command(BaseCommand):
 
                     if options['icons']:
                         icon_name = '{}_{}.png'.format(report.bucket, handle)
-                        icon_phash = static_analysis.get_icon_and_phash(storage_helper, icon_name)
+                        source = report.application.source
+                        icon_phash = static_analysis.get_icon_and_phash(storage_helper, icon_name, source)
                         if icon_phash:
                             report.application.icon_path = icon_name
                             report.application.save()


### PR DESCRIPTION
This part of theses scripts is barely used, so did not notice before the bug, present since we added F-Droid source into exodus.

Tested locally with success :heavy_check_mark: 
We most probably should have test for these cases, but I do not have the time right now to add them.