### PR TITLE
Upgrade Minio and RabbitMQ server

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -186,11 +186,11 @@ mkdir -p /tmp/exodus-storage
 #### 8 - Start Minio
 
 ```bash
-$HOME/minio server /tmp/exodus-storage
+$HOME/minio server /tmp/exodus-storage --console-address :9001
 ```
 
-Minio is now listening on `9000` port and the browser interface is available
-at [http://127.0.0.1:9000](http://127.0.0.1:9000). Use `exodusexodus` as both login
+Minio API is now listening on `9000` port and the browser interface is available
+at [http://127.0.0.1:9001](http://127.0.0.1:9001). Use `exodusexodus` as both login
 and password.
 
 #### 9 - Configure your instance

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,8 +68,8 @@ services:
   minio:
     command: ["minio", "server", "/data", "--console-address", ":9001"]
     environment:
-      MINIO_ACCESS_KEY: exodusexodus
-      MINIO_SECRET_KEY: exodusexodus
+      MINIO_ROOT_USER: exodusexodus
+      MINIO_ROOT_PASSWORD: exodusexodus
     image: minio/minio:RELEASE.2022-03-14T18-25-24Z
     networks:
       backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   amqp:
-    image: rabbitmq:3.7-alpine
+    image: rabbitmq:3.8.9-alpine
     networks:
       backend:
         aliases:
@@ -66,17 +66,18 @@ services:
       - ./exodus:/exodus/exodus:rw,cached
 
   minio:
-    command: ["minio", "server", "/data"]
+    command: ["minio", "server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ACCESS_KEY: exodusexodus
       MINIO_SECRET_KEY: exodusexodus
-    image: minio/minio:RELEASE.2019-10-12T01-39-57Z
+    image: minio/minio:RELEASE.2022-03-14T18-25-24Z
     networks:
       backend:
         aliases:
             - minio
     ports:
       - "9000:9000"
+      - "9001:9001"
     volumes:
       - minio:/data
 

--- a/exodus/exodus/settings/common_dev.py
+++ b/exodus/exodus/settings/common_dev.py
@@ -12,8 +12,8 @@ STATIC_URL = '/static/'
 STATIC_ROOT = '/static/'
 STATICFILES_DIRS = (os.path.join(BASE_DIR, '..', 'static'), )
 
-MINIO_STORAGE_ACCESS_KEY = os.environ.get('EXODUS_MINIO_ACCESS_KEY', 'exodusexodus')
-MINIO_STORAGE_SECRET_KEY = os.environ.get('EXODUS_MINIO_SECRET_KEY', 'exodusexodus')
+MINIO_STORAGE_ACCESS_KEY = os.environ.get('EXODUS_MINIO_ROOT_USER', 'exodusexodus')
+MINIO_STORAGE_SECRET_KEY = os.environ.get('EXODUS_MINIO_ROOT_PASSWORD', 'exodusexodus')
 
 ALLOW_APK_UPLOAD = True
 


### PR DESCRIPTION
- Set RabbitMQ server to [version 3.8.9](https://packages.debian.org/bullseye/rabbitmq-server)
- Set Minio to [version RELEASE.2022-03-14T18-25-24Z](https://dl.min.io/server/minio/release/linux-amd64/)
- Update Minio run command with [new `--console-address` argument for web interface](https://docs.min.io/minio/baremetal/console/minio-console.html#static-vs-dynamic-port-assignment)
- Replace [`MINIO_ACCESS_KEY`](https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#envvar.MINIO_ACCESS_KEY) and [`MINIO_SECRET_KEY`](https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#envvar.MINIO_SECRET_KEY) by [`MINIO_ROOT_USER`](https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#envvar.MINIO_ROOT_USER) and [`MINIO_ROOT_PASSWORD`](https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#envvar.MINIO_ROOT_PASSWORD)
- Update documentation