### PR TITLE
ci: Optimize order of jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - v1
-    tags:
-      - v*
   pull_request:
     branches:
       - v1
@@ -84,18 +82,3 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: false
-
-  release:
-    needs:
-      - build
-      - hadolint
-      - docker_build
-    name: Create Github release
-    if: github.event_name == 'push' && github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Create release
-        run: gh release create ${GITHUB_REF_NAME} --title ${GITHUB_REF_NAME} --generate-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,15 +57,25 @@ jobs:
         run: |
           pipenv check
         continue-on-error: true
-      - uses: hadolint/hadolint-action@v2.1.0
-        with:
-          dockerfile: docker/Dockerfile
       - name: Run tests
         run: |
           cd exodus
           python manage.py test
         env:
           DJANGO_SETTINGS_MODULE: exodus.settings.dev
+
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v2.1.0
+        with:
+          dockerfile: docker/Dockerfile
+
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build
@@ -74,9 +84,12 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: false
-          
+
   release:
-    needs: build
+    needs:
+      - build
+      - hadolint
+      - docker_build
     name: Create Github release
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
           dockerfile: docker/Dockerfile
 
   docker_build:
+    needs: hadolint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+---
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    name: Create Github release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create release
+        run: gh release create ${GITHUB_REF_NAME} --title ${GITHUB_REF_NAME} --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Run some tasks in parallel to make our whole CI pipeline faster
* Allows to see more easily which task fails
* Separate workflows to make it clearer and prevent skipped job on each pipeline
* Does not run tests on tag pipeline (we already test each commit)