### PR TITLE
fix: Use correct link to see existing api keys

### DIFF
--- a/exodus/trackers/templates/new_api_key.html
+++ b/exodus/trackers/templates/new_api_key.html
@@ -35,6 +35,9 @@
       </div>
       <button type="submit" class="btn btn-primary mt-2">Create new API key</button>
     </form>
+    <div class="mt-4">
+      <a target="_blank" href="{% url 'admin:authtoken_tokenproxy_changelist' %}">See existing API keys</a>
+    </div>
     {% else %}
     <div class="alert alert-danger small">
       <strong>{% trans "You need to be registered" %}.</strong>


### PR DESCRIPTION
Fixes #502 

The view changed from `authtoken_token_changelist` to `authtoken_tokenproxy_changelist` which broke the link (and the page).

Used [django-extensions](https://django-extensions.readthedocs.io/en/latest/) to find the new view name!