### PR TITLE
fix: Make sure all app icons are square

### DIFF
--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -14,7 +14,7 @@
 
   <div class="row justify-content-sm-center">
     <div class="col-xl-2 col-lg-2 col-md-8 col-12 text-lg-left text-center mb-4">
-      <img src="/reports/{{ report.application.id }}/icon" class="rounded" width="115" alt="{{ report.application.handle }} logo">
+      <img src="/reports/{{ report.application.id }}/icon" class="rounded" width="115" height="115" alt="{{ report.application.handle }} logo">
     </div>
     <div class="col-xl-6 col-lg-6 col-md-8 col-12 text-center text-lg-left my-auto mb-4">
       <h1 class="main-title">

--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -38,7 +38,7 @@
       <br>
       <div class="row position-relative">
         <div class="col-3 col-sm-2 col-md-2 my-auto">
-          <img src="/reports/{{ app.id }}/icon" width="50" class="rounded" alt="{{ app.handle }}">
+          <img src="/reports/{{ app.id }}/icon" width="50" height="50" class="rounded" alt="{{ app.handle }}">
         </div>
         <div class="col-9 col-sm-10 col-md-10 text-truncate position-static">
           <div>

--- a/exodus/trackers/templates/tracker_details.html
+++ b/exodus/trackers/templates/tracker_details.html
@@ -71,7 +71,7 @@
 {% with report.application as app %}
 <div class="row justify-content-sm-center position-relative mb-2">
   <div class="col-md-1 col-2 my-auto">
-    <img src="/reports/{{ app.id }}/icon" width="50" class="rounded" alt="{{ app.handle }}">
+    <img src="/reports/{{ app.id }}/icon" width="50" height="50" class="rounded" alt="{{ app.handle }}">
   </div>
   <div class="col-md-7 col-8 text-truncate position-static">
     <div>

--- a/exodus/web/templates/snippets/reports_search_tpl.html
+++ b/exodus/web/templates/snippets/reports_search_tpl.html
@@ -9,7 +9,7 @@
       <br>
       <div class="row position-relative">
         <div class="col-3 col-sm-2 col-md-2 my-auto">
-          <img class="rounded" src="/reports/{{handle}}/latest/icon" width="50" alt="{{handle}} logo">
+          <img class="rounded" src="/reports/{{handle}}/latest/icon" width="50" height="50" alt="{{handle}} logo">
         </div>
         <div class="col-9 col-sm-10 col-md-10 text-truncate position-static">
           <div>


### PR DESCRIPTION
Fixes #523 

Silly fix to make sure our rendering is not broken because of app icons which would not be square.
I'm not sure how this happened actually because in this particular case, the icon does not look like this in the Google Play store page.

**Before**

![image](https://user-images.githubusercontent.com/6069449/193409596-54515f65-01f5-44d5-91e7-441f0affe652.png)

**After**

![image](https://user-images.githubusercontent.com/6069449/193409608-aab7d5e2-7ce8-435f-96df-0642d52a4beb.png)
