### PR TITLE
feat: Only return latest report when exact handle searched

### DIFF
--- a/exodus/restful_api/views.py
+++ b/exodus/restful_api/views.py
@@ -212,9 +212,9 @@ def get_report_details(request, r_id):
 
 
 def _get_applications(input, limit):
-    exact_handle_matches = Application.objects.filter(Q(handle=input)).order_by('name', 'handle', '-report__creation_date').distinct('name', 'handle')[:limit]
-    if exact_handle_matches.count() > 0:
-        return exact_handle_matches
+    exact_handle_match = Application.objects.filter(handle=input).order_by('-report__creation_date')
+    if exact_handle_match.count() > 0:
+        return exact_handle_match[:1]
 
     applications = Application.objects.annotate(
         similarity=TrigramSimilarity('name', input),


### PR DESCRIPTION
Fixes #517 

Following discussion on the issue above, it seemed to me that when a user looks for an exact handle which we have already analyzed, we should only return the latest report.

Note that in the first result below, all reports links lead to the same report result, the one for version 7.7.0 with this link: https://reports.exodus-privacy.eu.org/en/reports/fr.meteo/latest/

**Before**

![image](https://user-images.githubusercontent.com/6069449/193913337-ee92e8c8-209f-47af-a663-1fe793d9d353.png)

**After**

![image](https://user-images.githubusercontent.com/6069449/193913477-a0ef2732-c4ea-4994-a158-331d133f5387.png)
