### PR TITLE
chore: Use timer to query API fewer times on submission page

### DIFF
--- a/exodus/analysis_query/templates/query_submit.html
+++ b/exodus/analysis_query/templates/query_submit.html
@@ -146,7 +146,13 @@
     }
   }
 
+  var search_timer = 0
+
   jQuery("#handle").on("input", function () {
+    if (search_timer) {
+      clearTimeout(search_timer)
+    }
+
     // Extract handle from Google Play or F-Droid url
     const gplay_regex = /id=((?:\w+\.)+\w+)/gmi;
     const fdroid_regex = /packages\/((?:\w+\.)+\w+)/gmi;
@@ -173,7 +179,7 @@
         return
       }
     } else {
-      check_existing_report(handle)
+      search_timer = setTimeout(function () { check_existing_report(handle); }, 200);
     }
   });
 


### PR DESCRIPTION
Currently on the submission page, if you type manually the handle it will call the API for each character you type.

This adds a timer to reduce the number of calls, the same way we do on the home page.