### PR TITLE
feat(api): Add tracker option to applications API endpoint

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -146,6 +146,24 @@ The API is served by the URL <https://reports.exodus-privacy.eu.org/>
 }
 ```
 
+#### Get all analyzed applications with a specific tracker found
+
+`GET /api/applications?tracker=<tracker_id>` returns `JSON`
+
+```json
+{
+  "applications": [
+    {
+      "id": 1,
+      "handle": "com.johnson.nett",
+      "app_uid": "C585E0D6274EDA2FA159542E305D2C61963BA8CC",
+      "source": "google"
+    },
+    [edited]
+  ]
+}
+```
+
 #### Get the number of distinct applications
 
 `GET /api/applications/count` returns `JSON`

--- a/exodus/restful_api/tests.py
+++ b/exodus/restful_api/tests.py
@@ -137,6 +137,58 @@ class RestfulApiApplicationTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected_json)
 
+    def test_returns_applications_with_specific_tracker_using_option_tracker_and_short(self):
+        self._force_authentication()
+        report_with_tracker_1 = Report.objects.create(id=1234)
+        tracker_1 = Tracker.objects.create(name='Teemo')
+        tracker_2 = Tracker.objects.create(name='Analytics')
+        report_with_tracker_1.found_trackers.set([tracker_1.id])
+        application_with_tracker_1 = Application.objects.create(
+            name='app_name1',
+            handle='handle1',
+            source='google1',
+            report=report_with_tracker_1
+        )
+
+        report_with_no_trackers = Report.objects.create(id=1235)
+        Application.objects.create(
+            name='app_name2',
+            handle='handle2',
+            source='google2',
+            report=report_with_no_trackers
+        )
+
+        report_with_both_trackers = Report.objects.create(id=1236)
+        report_with_both_trackers.found_trackers.set([tracker_1.id, tracker_2.id])
+        application_with_both_trackers = Application.objects.create(
+            name='app_name3',
+            handle='handle3',
+            source='google3',
+            report=report_with_both_trackers
+        )
+
+        expected_json = {
+            'applications': [
+                {
+                    "id": application_with_tracker_1.id,
+                    "handle": application_with_tracker_1.handle,
+                    "app_uid": "",
+                    "source": application_with_tracker_1.source
+                },
+                {
+                    "id": application_with_both_trackers.id,
+                    "handle": application_with_both_trackers.handle,
+                    "app_uid": "",
+                    "source": application_with_both_trackers.source
+                }
+            ]
+        }
+
+        response = self.client.get(self.PATH + f'?option=short&tracker={tracker_1.id}')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected_json)
+
 
 class RestfulApiSearchHandleDetailsTests(APITestCase):
     PATH = '/api/search/{}/details'.format(DUMMY_HANDLE)

--- a/exodus/restful_api/views.py
+++ b/exodus/restful_api/views.py
@@ -156,7 +156,11 @@ def get_all_trackers(request):
 def get_all_applications(request):
     if request.method == 'GET':
         try:
-            applications = Application.objects.order_by('handle', '-source').distinct('handle', 'source')
+            if request.GET.get('tracker'):
+                tracker_id = request.GET.get('tracker')
+                applications = Application.objects.filter(report__found_trackers__id=tracker_id).order_by('handle', '-source').distinct('handle', 'source')
+            else:
+                applications = Application.objects.order_by('handle', '-source').distinct('handle', 'source')
             if request.GET.get('option', 'full') == 'short':
                 serializer = ApplicationShortSerializer(applications, many=True)
             else:


### PR DESCRIPTION
Fixes #584  (using option 2)

Allows to look for all applications found with a specific tracker inside

Pretty straightforward change with a test