### PR TITLE
Improve titles and Open Graph properties

### DIFF
--- a/exodus/analysis_query/templates/query_error.html
+++ b/exodus/analysis_query/templates/query_error.html
@@ -1,5 +1,6 @@
 {% extends "base/base.html"%}
 {% block head %}
+  <meta  property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/analysis_query/templates/query_error.html
+++ b/exodus/analysis_query/templates/query_error.html
@@ -1,5 +1,7 @@
 {% extends "base/base.html"%}
 {% block head %}
+  <meta property="og:description" content="{% trans "Error during an analysis" %}">
+  <meta name="description" content="{% trans "Error during an analysis" %}">
   <meta  property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}

--- a/exodus/analysis_query/templates/query_error.html
+++ b/exodus/analysis_query/templates/query_error.html
@@ -1,4 +1,7 @@
 {% extends "base/base.html"%}
+{% block head %}
+  <title>{% trans "New analysis" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-12 col-centered">

--- a/exodus/analysis_query/templates/query_error.html
+++ b/exodus/analysis_query/templates/query_error.html
@@ -2,7 +2,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "Error during an analysis" %}">
   <meta name="description" content="{% trans "Error during an analysis" %}">
-  <meta  property="og:title" content="{% trans "New analysis" %}">
+  <meta property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/analysis_query/templates/query_submit.html
+++ b/exodus/analysis_query/templates/query_submit.html
@@ -3,6 +3,9 @@
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
+  <meta property="og:description" content="{% trans "Submit an application handle or URL to run a new analysis" %}">
+  <meta name="description" content="{% trans "Submit an application handle or URL to run a new analysis" %}">
+  <meta  property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/analysis_query/templates/query_submit.html
+++ b/exodus/analysis_query/templates/query_submit.html
@@ -5,7 +5,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "Submit an application handle or URL to run a new analysis" %}">
   <meta name="description" content="{% trans "Submit an application handle or URL to run a new analysis" %}">
-  <meta  property="og:title" content="{% trans "New analysis" %}">
+  <meta property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/analysis_query/templates/query_submit.html
+++ b/exodus/analysis_query/templates/query_submit.html
@@ -2,6 +2,9 @@
 {% load i18n %}
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
+{% block head %}
+  <title>{% trans "New analysis" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-12 text-center mb-4">

--- a/exodus/analysis_query/templates/query_upload.html
+++ b/exodus/analysis_query/templates/query_upload.html
@@ -2,6 +2,9 @@
 {% load i18n %}
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
+{% block head %}
+  <title>{% trans "New analysis" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-12 text-center mb-4">

--- a/exodus/analysis_query/templates/query_upload.html
+++ b/exodus/analysis_query/templates/query_upload.html
@@ -5,7 +5,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "Upload an APK file to run a new analysis" %}">
   <meta name="description" content="{% trans "Upload an APK file to run a new analysis" %}">
-  <meta  property="og:title" content="{% trans "New analysis" %}">
+  <meta property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/analysis_query/templates/query_upload.html
+++ b/exodus/analysis_query/templates/query_upload.html
@@ -3,6 +3,8 @@
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
+  <meta property="og:description" content="{% trans "Upload an APK file to run a new analysis" %}">
+  <meta name="description" content="{% trans "Upload an APK file to run a new analysis" %}">
   <meta  property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}

--- a/exodus/analysis_query/templates/query_upload.html
+++ b/exodus/analysis_query/templates/query_upload.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/analysis_query/templates/query_wait.html
+++ b/exodus/analysis_query/templates/query_wait.html
@@ -2,6 +2,9 @@
 {% load i18n %}
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
+{% block head %}
+  <title>{% trans "New analysis" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-12 text-center mb-4">

--- a/exodus/analysis_query/templates/query_wait.html
+++ b/exodus/analysis_query/templates/query_wait.html
@@ -3,6 +3,8 @@
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
+  <meta property="og:description" content="{% trans "In progress or completed analysis" %}">
+  <meta name="description" content="{% trans "In progress or completed analysis" %}">
   <meta  property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}

--- a/exodus/analysis_query/templates/query_wait.html
+++ b/exodus/analysis_query/templates/query_wait.html
@@ -5,7 +5,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "In progress or completed analysis" %}">
   <meta name="description" content="{% trans "In progress or completed analysis" %}">
-  <meta  property="og:title" content="{% trans "New analysis" %}">
+  <meta property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/analysis_query/templates/query_wait.html
+++ b/exodus/analysis_query/templates/query_wait.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "New analysis" %}">
   <title>{% trans "New analysis" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -1,6 +1,11 @@
 {% extends "base/base.html"%}
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
+{% block head %}
+  {% if report %}
+    <title>{% trans "Report for" %} {{ report.application.handle }} {{ report.application.version }} - εxodus</title>
+  {% endif %}
+{% endblock %}
 {% block content %}
   {% load static %}
   {% if report %}

--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -5,7 +5,7 @@
   {% if report %}
     <meta property="og:description" content="{% trans "Known trackers, permissions and informations about this specific version of this application" %}">
     <meta name="description" content="{% trans "Known trackers, permissions and informations about this specific version of this application" %}">
-    <meta  property="og:title" content="{% trans "Report for" %} {{ report.application.handle }} {{ report.application.version }}">
+    <meta property="og:title" content="{% trans "Report for" %} {{ report.application.handle }} {{ report.application.version }}">
     <title>{% trans "Report for" %} {{ report.application.handle }} {{ report.application.version }} - εxodus</title>
   {% endif %}
 {% endblock %}

--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -3,6 +3,7 @@
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
   {% if report %}
+    <meta  property="og:title" content="{% trans "Report for" %} {{ report.application.handle }} {{ report.application.version }}">
     <title>{% trans "Report for" %} {{ report.application.handle }} {{ report.application.version }} - εxodus</title>
   {% endif %}
 {% endblock %}

--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -3,6 +3,8 @@
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
   {% if report %}
+    <meta property="og:description" content="{% trans "Known trackers, permissions and informations about this specific version of this application" %}">
+    <meta name="description" content="{% trans "Known trackers, permissions and informations about this specific version of this application" %}">
     <meta  property="og:title" content="{% trans "Report for" %} {{ report.application.handle }} {{ report.application.version }}">
     <title>{% trans "Report for" %} {{ report.application.handle }} {{ report.application.version }} - εxodus</title>
   {% endif %}

--- a/exodus/reports/templates/reports_home.html
+++ b/exodus/reports/templates/reports_home.html
@@ -1,6 +1,9 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
+{% block head %}
+  <title>{% trans "Reports" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   {% load static %}
   <div class="row justify-content-md-center">

--- a/exodus/reports/templates/reports_home.html
+++ b/exodus/reports/templates/reports_home.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "Reports" %}">
   <title>{% trans "Reports" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/reports/templates/reports_home.html
+++ b/exodus/reports/templates/reports_home.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
+  <meta property="og:description" content="{% trans "Search reports by application name, handle or URL" %}">
+  <meta name="description" content="{% trans "Search reports by application name, handle or URL" %}">
   <meta  property="og:title" content="{% trans "Reports" %}">
   <title>{% trans "Reports" %} - εxodus</title>
 {% endblock %}

--- a/exodus/reports/templates/reports_home.html
+++ b/exodus/reports/templates/reports_home.html
@@ -4,7 +4,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "Search reports by application name, handle or URL" %}">
   <meta name="description" content="{% trans "Search reports by application name, handle or URL" %}">
-  <meta  property="og:title" content="{% trans "Reports" %}">
+  <meta property="og:title" content="{% trans "Reports" %}">
   <title>{% trans "Reports" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -3,8 +3,10 @@
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
   {% if handle %}
+    <meta  property="og:title" content="{% trans "Reports list for" %} {{ handle }}">
     <title>{% trans "Reports list for" %} {{ handle }} - εxodus</title>
   {% else %}
+    <meta  property="og:title" content="{% trans "Reports list" %}">
     <title>{% trans "Reports list" %} - εxodus</title>
   {% endif %}
 {% endblock %}

--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -3,9 +3,13 @@
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
   {% if handle %}
+    <meta property="og:description" content="{% trans "Reports of all analyzed versions of this application" %}">
+    <meta name="description" content="{% trans "Reports of all analyzed versions of this application" %}">
     <meta  property="og:title" content="{% trans "Reports list for" %} {{ handle }}">
     <title>{% trans "Reports list for" %} {{ handle }} - εxodus</title>
   {% else %}
+    <meta property="og:description" content="{% trans "All applications reports sorted by latest reports, number of trackers or no known trackers" %}">
+    <meta name="description" content="{% trans "All applications reports sorted by latest reports, number of trackers or no known trackers" %}">
     <meta  property="og:title" content="{% trans "Reports list" %}">
     <title>{% trans "Reports list" %} - εxodus</title>
   {% endif %}

--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -1,6 +1,13 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
+{% block head %}
+  {% if handle %}
+    <title>{% trans "Reports list for" %} {{ handle }} - εxodus</title>
+  {% else %}
+    <title>{% trans "Reports list" %} - εxodus</title>
+  {% endif %}
+{% endblock %}
 {% block content %}
   {% load static %}
   <div class="row justify-content-md-center">

--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -5,12 +5,12 @@
   {% if handle %}
     <meta property="og:description" content="{% trans "Reports of all analyzed versions of this application" %}">
     <meta name="description" content="{% trans "Reports of all analyzed versions of this application" %}">
-    <meta  property="og:title" content="{% trans "Reports list for" %} {{ handle }}">
+    <meta property="og:title" content="{% trans "Reports list for" %} {{ handle }}">
     <title>{% trans "Reports list for" %} {{ handle }} - εxodus</title>
   {% else %}
     <meta property="og:description" content="{% trans "All applications reports sorted by latest reports, number of trackers or no known trackers" %}">
     <meta name="description" content="{% trans "All applications reports sorted by latest reports, number of trackers or no known trackers" %}">
-    <meta  property="og:title" content="{% trans "Reports list" %}">
+    <meta property="og:title" content="{% trans "Reports list" %}">
     <title>{% trans "Reports list" %} - εxodus</title>
   {% endif %}
 {% endblock %}

--- a/exodus/trackers/templates/stats_details.html
+++ b/exodus/trackers/templates/stats_details.html
@@ -1,5 +1,8 @@
 {% extends "base/base.html" %}
 {% load i18n %}
+{% block head %}
+  <title>{% trans "Statistics" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   {% load static %}
   <div class="row justify-content-md-center mb-4">

--- a/exodus/trackers/templates/stats_details.html
+++ b/exodus/trackers/templates/stats_details.html
@@ -1,6 +1,7 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "Statistics" %}">
   <title>{% trans "Statistics" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/trackers/templates/stats_details.html
+++ b/exodus/trackers/templates/stats_details.html
@@ -3,7 +3,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "Most frequent trackers" %}">
   <meta name="description" content="{% trans "Most frequent trackers" %}">
-  <meta  property="og:title" content="{% trans "Statistics" %}">
+  <meta property="og:title" content="{% trans "Statistics" %}">
   <title>{% trans "Statistics" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/trackers/templates/stats_details.html
+++ b/exodus/trackers/templates/stats_details.html
@@ -1,6 +1,8 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% block head %}
+  <meta property="og:description" content="{% trans "Most frequent trackers" %}">
+  <meta name="description" content="{% trans "Most frequent trackers" %}">
   <meta  property="og:title" content="{% trans "Statistics" %}">
   <title>{% trans "Statistics" %} - εxodus</title>
 {% endblock %}

--- a/exodus/trackers/templates/tracker_details.html
+++ b/exodus/trackers/templates/tracker_details.html
@@ -1,6 +1,9 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% load markdown %}
+{% block head %}
+  <title>{% trans "Tracker profile for" %} {{ tracker.name }} - εxodus</title>
+{% endblock %}
 {% block content %}
   <style>
     h2 {

--- a/exodus/trackers/templates/tracker_details.html
+++ b/exodus/trackers/templates/tracker_details.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load markdown %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "Tracker profile for" %} {{ tracker.name }}">
   <title>{% trans "Tracker profile for" %} {{ tracker.name }} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/trackers/templates/tracker_details.html
+++ b/exodus/trackers/templates/tracker_details.html
@@ -4,7 +4,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "Informations about this tracker" %}">
   <meta name="description" content="{% trans "Informations about this tracker" %}">
-  <meta  property="og:title" content="{% trans "Tracker profile for" %} {{ tracker.name }}">
+  <meta property="og:title" content="{% trans "Tracker profile for" %} {{ tracker.name }}">
   <title>{% trans "Tracker profile for" %} {{ tracker.name }} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/trackers/templates/tracker_details.html
+++ b/exodus/trackers/templates/tracker_details.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load markdown %}
 {% block head %}
+  <meta property="og:description" content="{% trans "Informations about this tracker" %}">
+  <meta name="description" content="{% trans "Informations about this tracker" %}">
   <meta  property="og:title" content="{% trans "Tracker profile for" %} {{ tracker.name }}">
   <title>{% trans "Tracker profile for" %} {{ tracker.name }} - εxodus</title>
 {% endblock %}

--- a/exodus/trackers/templates/trackers_list.html
+++ b/exodus/trackers/templates/trackers_list.html
@@ -1,6 +1,7 @@
 {% extends "base/base.html"%}
 {% load i18n %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "Trackers" %}">
   <title>{% trans "Trackers" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/trackers/templates/trackers_list.html
+++ b/exodus/trackers/templates/trackers_list.html
@@ -1,5 +1,8 @@
 {% extends "base/base.html"%}
 {% load i18n %}
+{% block head %}
+  <title>{% trans "Trackers" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   {% if trackers %}
     <div class="row justify-content-sm-center">

--- a/exodus/trackers/templates/trackers_list.html
+++ b/exodus/trackers/templates/trackers_list.html
@@ -1,6 +1,8 @@
 {% extends "base/base.html"%}
 {% load i18n %}
 {% block head %}
+  <meta property="og:description" content="{% trans "List of known trackers" %}">
+  <meta name="description" content="{% trans "List of known trackers" %}">
   <meta  property="og:title" content="{% trans "Trackers" %}">
   <title>{% trans "Trackers" %} - εxodus</title>
 {% endblock %}

--- a/exodus/trackers/templates/trackers_list.html
+++ b/exodus/trackers/templates/trackers_list.html
@@ -3,7 +3,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "List of known trackers" %}">
   <meta name="description" content="{% trans "List of known trackers" %}">
-  <meta  property="og:title" content="{% trans "Trackers" %}">
+  <meta property="og:title" content="{% trans "Trackers" %}">
   <title>{% trans "Trackers" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/base.html
+++ b/exodus/web/templates/base/base.html
@@ -14,7 +14,11 @@
     <script src="{% static "js/bootstrap.min.js" %}"></script>
     <script src="{% static "js/handlebars.min.js" %}"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="εxodus">
+    <meta  property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{% static "img/logo_purple_without_text.png" %}">
     {% block head %}
+      <meta  property="og:title" content="εxodus">
       <title>εxodus</title>
     {% endblock %}
   </head>

--- a/exodus/web/templates/base/base.html
+++ b/exodus/web/templates/base/base.html
@@ -14,7 +14,9 @@
     <script src="{% static "js/bootstrap.min.js" %}"></script>
     <script src="{% static "js/handlebars.min.js" %}"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>εxodus</title>
+    {% block head %}
+      <title>εxodus</title>
+    {% endblock %}
   </head>
 
   <body>

--- a/exodus/web/templates/base/home.html
+++ b/exodus/web/templates/base/home.html
@@ -1,9 +1,9 @@
 {% extends "base/base.html"%}
 {% load i18n %}
 {% block head %}
-  <meta  property="og:description" content="{% trans "The privacy audit platform for Android applications" %}">
-  <meta  name="description" content="{% trans "The privacy audit platform for Android applications" %}">
-  <meta  property="og:title" content="{% trans "Home" %}">
+  <meta property="og:description" content="{% trans "The privacy audit platform for Android applications" %}">
+  <meta name="description" content="{% trans "The privacy audit platform for Android applications" %}">
+  <meta property="og:title" content="{% trans "Home" %}">
   <title>{% trans "Home" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/home.html
+++ b/exodus/web/templates/base/home.html
@@ -1,6 +1,9 @@
 {% extends "base/base.html"%}
+{% load i18n %}
+{% block head %}
+  <title>{% trans "Home" %} - εxodus</title>
+{% endblock %}
 {% block content %}
-  {% load i18n %}
   <div class="row justify-content-center mb-5 mt-5">
     <div class="col-xl-3 col-lg-3 col-md-3 col-sm-4 col-4 my-auto">
       <img src="/static/img/logo_purple_small.svg" class="mx-auto d-block img-fluid" alt="exodus logo">

--- a/exodus/web/templates/base/home.html
+++ b/exodus/web/templates/base/home.html
@@ -1,6 +1,7 @@
 {% extends "base/base.html"%}
 {% load i18n %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "Home" %}">
   <title>{% trans "Home" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/home.html
+++ b/exodus/web/templates/base/home.html
@@ -1,6 +1,8 @@
 {% extends "base/base.html"%}
 {% load i18n %}
 {% block head %}
+  <meta  property="og:description" content="{% trans "The privacy audit platform for Android applications" %}">
+  <meta  name="description" content="{% trans "The privacy audit platform for Android applications" %}">
   <meta  property="og:title" content="{% trans "Home" %}">
   <title>{% trans "Home" %} - εxodus</title>
 {% endblock %}

--- a/exodus/web/templates/base/next.html
+++ b/exodus/web/templates/base/next.html
@@ -4,7 +4,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "We know it is not easy to find alternatives in order to escape trackers within our apps. We prepared a list of tools and things you can do to better manage your privacy on your smartphone." %}">
   <meta name="description" content="{% trans "We know it is not easy to find alternatives in order to escape trackers within our apps. We prepared a list of tools and things you can do to better manage your privacy on your smartphone." %}">
-  <meta  property="og:title" content="{% trans "What's next?" %}">
+  <meta property="og:title" content="{% trans "What's next?" %}">
   <title>{% trans "What's next?" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/next.html
+++ b/exodus/web/templates/base/next.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta property="og:description" content="{% trans "We know it is not easy to find alternatives in order to escape trackers within our apps. We prepared a list of tools and things you can do to better manage your privacy on your smartphone." %}">
+  <meta name="description" content="{% trans "We know it is not easy to find alternatives in order to escape trackers within our apps. We prepared a list of tools and things you can do to better manage your privacy on your smartphone." %}">
   <meta  property="og:title" content="{% trans "What's next?" %}">
   <title>{% trans "What's next?" %} - εxodus</title>
 {% endblock %}

--- a/exodus/web/templates/base/next.html
+++ b/exodus/web/templates/base/next.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "What's next?" %}">
   <title>{% trans "What's next?" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/next.html
+++ b/exodus/web/templates/base/next.html
@@ -1,6 +1,9 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% load static %}
+{% block head %}
+  <title>{% trans "What's next?" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-12 text-center mb-4">

--- a/exodus/web/templates/base/organization.html
+++ b/exodus/web/templates/base/organization.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "The organization" %}">
   <title>{% trans "The organization" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/organization.html
+++ b/exodus/web/templates/base/organization.html
@@ -4,7 +4,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "Exodus Privacy is a non-profit organization led by hacktivists. Its purpose is to help people get a better understanding of the Android applications tracking issues." %}">
   <meta name="description" content="{% trans "Exodus Privacy is a non-profit organization led by hacktivists. Its purpose is to help people get a better understanding of the Android applications tracking issues." %}">
-  <meta  property="og:title" content="{% trans "The organization" %}">
+  <meta property="og:title" content="{% trans "The organization" %}">
   <title>{% trans "The organization" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/organization.html
+++ b/exodus/web/templates/base/organization.html
@@ -1,6 +1,9 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% load static %}
+{% block head %}
+  <title>{% trans "The organization" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-12 text-center mb-4">

--- a/exodus/web/templates/base/organization.html
+++ b/exodus/web/templates/base/organization.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta property="og:description" content="{% trans "Exodus Privacy is a non-profit organization led by hacktivists. Its purpose is to help people get a better understanding of the Android applications tracking issues." %}">
+  <meta name="description" content="{% trans "Exodus Privacy is a non-profit organization led by hacktivists. Its purpose is to help people get a better understanding of the Android applications tracking issues." %}">
   <meta  property="og:title" content="{% trans "The organization" %}">
   <title>{% trans "The organization" %} - εxodus</title>
 {% endblock %}

--- a/exodus/web/templates/base/permissions.html
+++ b/exodus/web/templates/base/permissions.html
@@ -4,7 +4,7 @@
 {% block head %}
   <meta property="og:description" content="{% trans "What type of permissions? Why are some permissions indicated as dangerous? Do I have control over these permissions?" %}">
   <meta name="description" content="{% trans "What type of permissions? Why are some permissions indicated as dangerous? Do I have control over these permissions?" %}">
-  <meta  property="og:title" content="{% trans "Permissions" %}">
+  <meta property="og:title" content="{% trans "Permissions" %}">
   <title>{% trans "Permissions" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/permissions.html
+++ b/exodus/web/templates/base/permissions.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta property="og:description" content="{% trans "What type of permissions? Why are some permissions indicated as dangerous? Do I have control over these permissions?" %}">
+  <meta name="description" content="{% trans "What type of permissions? Why are some permissions indicated as dangerous? Do I have control over these permissions?" %}">
   <meta  property="og:title" content="{% trans "Permissions" %}">
   <title>{% trans "Permissions" %} - εxodus</title>
 {% endblock %}

--- a/exodus/web/templates/base/permissions.html
+++ b/exodus/web/templates/base/permissions.html
@@ -1,6 +1,9 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% load static %}
+{% block head %}
+  <title>{% trans "Permissions" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-12 text-center mb-4">

--- a/exodus/web/templates/base/permissions.html
+++ b/exodus/web/templates/base/permissions.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "Permissions" %}">
   <title>{% trans "Permissions" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/trackers.html
+++ b/exodus/web/templates/base/trackers.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
-  <meta  property="og:title" content="{% trans "Trackers" %}">
+  <meta property="og:description" content="{% trans "What is a tracker? Are all trackers created equal? Who puts these trackers in?" %}">
+  <meta name="description" content="{% trans "What is a tracker? Are all trackers created equal? Who puts these trackers in?" %}">
+  <meta property="og:title" content="{% trans "Trackers" %}">
   <title>{% trans "Trackers" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/trackers.html
+++ b/exodus/web/templates/base/trackers.html
@@ -1,6 +1,9 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% load static %}
+{% block head %}
+  <title>{% trans "Trackers" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center">
     <div class="col-md-8 col-12 text-center mb-4">

--- a/exodus/web/templates/base/trackers.html
+++ b/exodus/web/templates/base/trackers.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "Trackers" %}">
   <title>{% trans "Trackers" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/understand.html
+++ b/exodus/web/templates/base/understand.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta  property="og:description" content="{% trans "Better understand what are trackers, permissions and what to do next" %}">
+  <meta  name="description" content="{% trans "Better understand what are trackers, permissions and what to do next" %}">
   <meta  property="og:title" content="{% trans "Better understand" %}">
   <title>{% trans "Better understand" %} - εxodus</title>
 {% endblock %}

--- a/exodus/web/templates/base/understand.html
+++ b/exodus/web/templates/base/understand.html
@@ -1,6 +1,9 @@
 {% extends "base/base.html" %}
 {% load i18n %}
 {% load static %}
+{% block head %}
+  <title>{% trans "Better understand" %} - εxodus</title>
+{% endblock %}
 {% block content %}
   <div class="row justify-content-sm-center mb-4">
     <div class="col-md-8 col-12 text-center">

--- a/exodus/web/templates/base/understand.html
+++ b/exodus/web/templates/base/understand.html
@@ -2,9 +2,9 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
-  <meta  property="og:description" content="{% trans "Better understand what are trackers, permissions and what to do next" %}">
-  <meta  name="description" content="{% trans "Better understand what are trackers, permissions and what to do next" %}">
-  <meta  property="og:title" content="{% trans "Better understand" %}">
+  <meta property="og:description" content="{% trans "Better understand what are trackers, permissions and what to do next" %}">
+  <meta name="description" content="{% trans "Better understand what are trackers, permissions and what to do next" %}">
+  <meta property="og:title" content="{% trans "Better understand" %}">
   <title>{% trans "Better understand" %} - εxodus</title>
 {% endblock %}
 {% block content %}

--- a/exodus/web/templates/base/understand.html
+++ b/exodus/web/templates/base/understand.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% block head %}
+  <meta  property="og:title" content="{% trans "Better understand" %}">
   <title>{% trans "Better understand" %} - εxodus</title>
 {% endblock %}
 {% block content %}


### PR DESCRIPTION
## Goal

### Common to all pages

- Add Open Graph `type`: `article`
- Add Open Graph `site_name`: `εxodus`
- Add Open Graph `image`: default εxodus logo without text

### Specific for each page

- Add specific titles (with a fallback to `εxodus`)
- Add Open Graph titles
- Add description
- Add Open Graph description

## Information

Fix #59 and fix #142 