### PR TITLE
[Submit] Fix: remove "temporary" workaround for it & es languages

### DIFF
--- a/exodus/analysis_query/templates/query_submit.html
+++ b/exodus/analysis_query/templates/query_submit.html
@@ -27,7 +27,7 @@
           <b>{% trans "It is currently impossible to submit new analysis. Sorry for the inconvenience!" %}</b>
         </div>
       {% else %}
-        <form method="post" enctype="multipart/form-data" action="{% if LANGUAGE_CODE in 'fr,en' %}{% url 'analysis:submit' %}{% else %}/en/analysis/submit/{% endif %}">
+        <form method="post" enctype="multipart/form-data" action="{% url 'analysis:submit' %}">
           <div class="form-group">
             {% csrf_token %}
             {% if form.errors %}


### PR DESCRIPTION
## Goal

Permit Submit page to be available in all languages by removing a condition.

## Information

This strange workaround was introduced in Exodus version `1.14.2` (https://github.com/Exodus-Privacy/exodus/commit/fa6ec77a4a7096e7dd00ac9a1950d29ef73f0988).

I don't really know why it was introduce, a missing translation issue maybe?

Feel free to comment if you know why we do this :smile_cat: 