### PR TITLE
feat: add version label to search results for clarity

### DIFF
--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -63,7 +63,7 @@
                       {% endif %}
                     </a>
                   </div>
-                  <div class="small"><b>{{ app.version|truncatechars_html:20 }}{% if app.source %} - {{ app.source }}{% endif %}</b></div>
+                  <div class="small"><b>{% trans "Version" %} {{ app.version|truncatechars_html:20 }}{% if app.source %} - {{ app.source }}{% endif %}</b></div>
                   <div>
                     {% with nb_trackers=report.found_trackers.count %}
                       <span class="mr-lg-4 mr-2">

--- a/exodus/trackers/templates/tracker_details.html
+++ b/exodus/trackers/templates/tracker_details.html
@@ -89,7 +89,7 @@
               {% endif %}
             </a>
           </div>
-          <div class="small"><b>{{ app.version }}{% if app.source %} - {{ app.source }}{% endif %}</b></div>
+          <div class="small"><b>{% trans "Version" %} {{ app.version }}{% if app.source %} - {{ app.source }}{% endif %}</b></div>
         </div>
       </div>
     {% endwith %}

--- a/exodus/web/templates/snippets/reports_search_tpl.html
+++ b/exodus/web/templates/snippets/reports_search_tpl.html
@@ -21,7 +21,7 @@
               {{/if}}
             </a>
           </div>
-          <div class="small"><b>{{version}}</b></div>
+          <div class="small"><b>{% endverbatim %}{% trans "Version" %}{% verbatim %} {{version}}</b></div>
           <div>
             <span class="mr-lg-4 mr-2">
               <span class="badge badge-pill badge-{{trackers_class}} reports">{{trackers_count}}</span>


### PR DESCRIPTION
## PR Summary
This PR improves clarity of version numbers displayed in search results by adding a "Version" label prefix. 
Example 1:

<img width="490" height="192" alt="image" src="https://github.com/user-attachments/assets/b8038c33-5542-4fef-bf2a-9807ca72a93a" />

Example 2:
<img width="390" height="252" alt="image" src="https://github.com/user-attachments/assets/a98a4ace-f336-46a0-a7e3-354fa217d34d" />


Fixes #651.