### PR TITLE
[Licence] Add ODbL licence for database and API results

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,5 @@ Check the [FAQ](doc/faq.md) if you encounter any problem or need an extended doc
 ## License
 
 This project is licensed under the GNU AGPL v3 License - see the [LICENSE](LICENSE) file for details.
+
+The εxodus database and API results are made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in individual contents of the database are licensed under the Database Contents License: http://opendatacommons.org/licenses/dbcl/1.0/.

--- a/doc/api.md
+++ b/doc/api.md
@@ -8,6 +8,8 @@ This API is globally limited to 30 requests/second (with a 50 requests burst). S
 
 :warning: If the previous limit is exceeded too many times, we will ban the originating IP address for a specific period of time.
 
+The εxodus API results are made available under the Open Database License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in individual contents of the database are licensed under the Database Contents License: http://opendatacommons.org/licenses/dbcl/1.0/.
+
 ## Authorization
 
 **In order to use this REST API, you have to request an API key**.


### PR DESCRIPTION
# Goal

- Add [ODbL](https://opendatacommons.org/licenses/odbl/) Licence for εxodus database and API results

## Information

- Fix #561 