### PR TITLE
[Dependencies] Upgrade Apkeep from 0.17.0 to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 - Add a changelog
+- dependencies: upgrade apkeep from 0.17.0 to 0.18.0
 
 ## [1.32.2] - 2025-12-06
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.22 AS apkeep-download
+FROM alpine:3.23 AS apkeep-download
 
-ENV APKEEP_VERSION=0.17.0
+ENV APKEEP_VERSION=0.18.0
 
 RUN wget https://github.com/EFForg/apkeep/releases/download/${APKEEP_VERSION}/apkeep-x86_64-unknown-linux-gnu -q -O /tmp/apkeep \
   && chmod +x /tmp/apkeep


### PR DESCRIPTION
# Goal

- Upgrade `apkeep` binary to version `0.18.0`

## Information

This release add ([correct in facts](https://github.com/EFForg/apkeep/commit/2f4a1597939789a8e8cf0ece68c5911a25577a7d)) some logs in standard outputs. I open [an issue asking if we can avoid this with an option](https://github.com/EFForg/apkeep/issues/223).