### PR TITLE
Fix typo: 'plateform' to 'platform' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please follow [Exodus Privacy's code of conduct](https://exodus-privacy.eu.org/e
 
 If you want to help us improve this project, you can:
 
-- [Translate the plateform](https://github.com/Exodus-Privacy/exodus#translation)
+- [Translate the platform](https://github.com/Exodus-Privacy/exodus#translation)
 - Use [issues](https://github.com/Exodus-Privacy/exodus/issues) to report bugs and propose ideas or feature requests
 - Join us on our [IRC channel #exodus-privacy on Libera.chat](https://web.libera.chat/?nick=webguest?#exodus-privacy)
 - Refer to [this documentation](CONTRIBUTING.md) to improve the code.
@@ -40,7 +40,7 @@ If you want to help us improve this project, you can:
 
 ### Translation
 
-Do you want to help to translate the plateform? Contribute here:
+Do you want to help to translate the platform? Contribute here:
 
 https://crowdin.com/project/exodus-privacy
 


### PR DESCRIPTION
Small fix for a recurring typo found in the documentation under the "Contributing" and "Translation" sections.

As I mentioned in my previous comment, I initially hesitated to open a PR for such a minor change to avoid cluttering the repository, but I'm happy to contribute this way to keep the docs clean!