### PR TITLE
feat(reports): explain tracker presence vs activity on report pages

### DIFF
--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -1,5 +1,6 @@
 {% extends "base/base.html"%}
 {% load i18n %}
+{% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 {% block head %}
   {% if report %}
@@ -105,6 +106,9 @@
         <h3>
           <span class="badge badge-pill badge-{{ report.application.trackers_class }} reports">{{ report.found_trackers.count }}</span>
           <b>{% blocktrans count count=report.found_trackers.count %}tracker{% plural %}trackers{% endblocktrans %}</b>
+          <a class="ml-2" data-toggle="tooltip" data-placement="top" title="{% trans "Trackers are detected by static analysis of the application code. Their presence does not mean they are active." %}" href="https://exodus-privacy.eu.org/en/page/faq/#negatives">
+            <img src="{% static 'img/info.svg' %}" alt="{% trans "More information about trackers" %}">
+          </a>
         </h3>
       </div>
       <div class="col-md-8 col-12">

--- a/exodus/reports/tests.py
+++ b/exodus/reports/tests.py
@@ -103,3 +103,16 @@ class ReportsViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['reports_total_count'], 2)
+
+    def test_report_details_page_explains_tracker_presence_is_not_proof_of_activity(self):
+        report = Report.objects.create()
+        Application.objects.create(name="App1", report=report, handle="com.test.track")
+
+        response = self.client.get('/en/reports/{}/'.format(report.id))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'exodus-privacy.eu.org/en/page/faq/#negatives'
+        )
+        self.assertContains(response, 'info.svg')

--- a/exodus/static/img/info.svg
+++ b/exodus/static/img/info.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" fill="#000000"/>
+</svg>


### PR DESCRIPTION
## What

Adds a short explanation on report detail pages that a tracker detected by static analysis is *present* in the application code, but that its presence does not prove it is *active*.

This has been a recurring source of confusion for users looking at report pages only (see the discussion in #638 — several people contacted the project by email/social media assuming any listed tracker means data collection is happening).

## How

- New `static/img/info.svg` info icon next to the trackers count heading.
- The icon shows a tooltip (same `data-toggle="tooltip"` pattern already used elsewhere on this page) with the explanation, and links to the FAQ section that goes into detail: https://exodus-privacy.eu.org/en/page/faq/#negatives

The existing note in the report footer stays; this makes the explanation visible right where the tracker count is read.

## Tests

- New test `test_report_details_page_explains_tracker_presence_is_not_proof_of_activity` rendering a report details page and asserting the FAQ link and icon are present.
- Full suite: `manage.py test` → 69/69 OK.
- `flake8` clean on changed files.
