### PR TITLE
fix(reports): serve app icons without language redirect

### DIFF
--- a/exodus/exodus/urls.py
+++ b/exodus/exodus/urls.py
@@ -4,6 +4,8 @@ from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.contrib import admin
 
+from reports.views import get_app_icon
+
 from . import views
 
 urlpatterns = [
@@ -11,6 +13,8 @@ urlpatterns = [
     path('api/', include('restful_api.urls')),
     path('admin/', admin.site.urls),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    path('reports/<int:app_id>/icon/', get_app_icon, name='app_icon'),
+    path('reports/<handle>/latest/icon/', get_app_icon, name='app_icon_by_handle'),
 ]
 
 urlpatterns += i18n_patterns(

--- a/exodus/reports/templates/report_details.html
+++ b/exodus/reports/templates/report_details.html
@@ -23,7 +23,7 @@
 
     <div class="row justify-content-sm-center">
       <div class="col-xl-2 col-lg-2 col-md-8 col-12 text-lg-left text-center mb-4">
-        <img src="/{{ LANGUAGE_CODE }}/reports/{{ report.application.id }}/icon/" class="rounded" width="115" height="115" alt="{{ report.application.handle }} logo">
+        <img src="{% url 'app_icon' report.application.id %}" class="rounded" width="115" height="115" alt="{{ report.application.handle }} logo">
       </div>
       <div class="col-xl-6 col-lg-6 col-md-8 col-12 text-center text-lg-left my-auto mb-4">
         <h1 class="main-title">

--- a/exodus/reports/tests.py
+++ b/exodus/reports/tests.py
@@ -51,6 +51,16 @@ class ReportsIconTests(TestCase):
         self.assertTrue(get_object.called)
         self.assertEqual(response.content, b'icon contents')
 
+    @patch('reports.views.Minio.get_object', autospec=True, return_value=Mock(data='icon contents'))
+    def test_icon_served_without_language_redirect(self, get_object):
+        r = Report.objects.create()
+        app = Application.objects.create(report=r, handle='com.example.app', version='1')
+
+        response = self.client.get('/reports/{}/icon/'.format(app.pk), follow=False)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(get_object.called)
+
 
 class ReportsViewTests(TestCase):
     REPORTS_PATH = '/en/reports/list/'


### PR DESCRIPTION
## What

App icon URLs (`/reports/<id>/icon` and `/reports/<handle>/latest/icon`) were only registered inside `i18n_patterns`. A request without a language prefix therefore fell through to a 404 and Django's `LocaleMiddleware` responded with a **302 redirect** to `/<lang>/reports/<id>/icon/`. Every icon `<img>` on the site paid that extra round-trip, and external references (scrapers, embeds) got redirected too. Fixes #557.

## Change

- Register the two icon endpoints as non-localized routes in the root `urls.py` (`reports/<int:app_id>/icon/` and `reports/<handle>/latest/icon/`), outside `i18n_patterns`. Icons are binary content, not localized pages — they don't need a language prefix.
- The language-prefixed routes remain for backward compatibility.
- `report_details.html` now uses `{% url 'app_icon' ... %}` instead of the hardcoded `/{LANGUAGE_CODE}/reports/...` workaround from #554.

## Tests

- New regression test `test_icon_served_without_language_redirect`: GET `/reports/<id>/icon/` (no language prefix, `follow=False`) now returns **200** directly; it previously returned **302** (verified by running the test with the routes removed — `AssertionError: 302 != 200`).
- Full suite: `manage.py test` → **69/69 OK** (existing icon tests unchanged).
- `flake8` clean on changed files.
