### PR TITLE
docs(next): add Framalibre to alternative resources

### DIFF
--- a/exodus/web/templates/base/next.html
+++ b/exodus/web/templates/base/next.html
@@ -92,6 +92,7 @@
           <ul>
             <li><a target='_blank' rel='noreferrer' href='https://prism-break.org/en/categories/android/'>Prism Break</a></li>
             <li><a target='_blank' rel='noreferrer' href='https://ssd.eff.org/'>Surveillance Self-Defense by EFF</a></li>
+            <li><a target='_blank' rel='noreferrer' href='https://framalibre.org/'>Framalibre</a></li>
           </ul>
         {% endblocktrans %}
       </p>

--- a/exodus/web/tests.py
+++ b/exodus/web/tests.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+
+
+class NextPageTests(TestCase):
+
+    def test_next_page_lists_framalibre_among_alternatives(self):
+        response = self.client.get('/en/info/next/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'https://framalibre.org/')


### PR DESCRIPTION
Adds [Framalibre](https://framalibre.org/) to the resources listed under "Discover alternatives" on the What's next? page (Closes #618).

Added a small view test (web/tests.py) asserting the page renders and the link is present. `manage.py test web` → OK.