### PR TITLE
fix(analysis): reject submissions without an application handle

### DIFF
--- a/exodus/analysis_query/forms.py
+++ b/exodus/analysis_query/forms.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from .models import AnalysisRequest
 
@@ -8,6 +9,13 @@ class AnalysisRequestForm(forms.ModelForm):
     class Meta:
         model = AnalysisRequest
         fields = ('handle', 'source')
+
+    def clean(self):
+        cleaned_data = super().clean()
+        handle = cleaned_data.get('handle')
+        if not handle:
+            self.add_error('handle', _('A handle is required to submit an analysis.'))
+        return cleaned_data
 
 
 class UploadRequestForm(forms.ModelForm):

--- a/exodus/analysis_query/tests.py
+++ b/exodus/analysis_query/tests.py
@@ -1,6 +1,24 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-# from django.test import TestCase
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import TestCase
+
+from .forms import AnalysisRequestForm
+
+
+class AnalysisRequestFormTests(TestCase):
+
+    def test_empty_handle_is_rejected(self):
+        form = AnalysisRequestForm(data={'handle': '', 'source': 'google'})
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('handle', form.errors)
+
+    @patch('analysis_query.models._is_app_in_store', return_value=True)
+    def test_valid_handle_is_accepted(self, mock_store):
+        form = AnalysisRequestForm(
+            data={'handle': 'com.example.app', 'source': 'google'})
+
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
## What

Submitting an analysis with an empty handle was accepted by the backend: the `handle` field is `blank=True` (needed for APK uploads), and Django's `run_validators` skips model validators for empty values of blank fields. The only guard was a client-side HTML check that can be bypassed (see #296 / #297).

## Change

`AnalysisRequestForm.clean()` now rejects an empty handle with a field error. The APK upload path (`UploadRequestForm`) is unchanged.

## Tests

- New `AnalysisRequestFormTests`: empty handle → form invalid with error on `handle`; valid handle (store lookup mocked) → valid.
- Verified the bug live first: `AnalysisRequestForm({'handle': '', 'source': 'google'}).is_valid()` returned `True` before the fix.
- Full suite → 69/69 OK; flake8 clean.

Fixes https://github.com/Exodus-Privacy/exodus/issues/297