### PR TITLE
feat: add cache for application icons

### DIFF
--- a/exodus/exodus/settings/base.py
+++ b/exodus/exodus/settings/base.py
@@ -172,6 +172,9 @@ MINIO_STORAGE_USE_HTTPS = False
 MINIO_STORAGE_MEDIA_BUCKET_NAME = 'exodus'
 MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET = True
 
+# Cache duration (in seconds) for application icons
+ICON_CACHE_MAX_AGE = 60 * 60 * 24 * 7  # 1 week
+
 # See https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 

--- a/exodus/reports/tests.py
+++ b/exodus/reports/tests.py
@@ -51,6 +51,27 @@ class ReportsIconTests(TestCase):
         self.assertTrue(get_object.called)
         self.assertEqual(response.content, b'icon contents')
 
+    @patch('reports.views.Minio.get_object', autospec=True, return_value=Mock(data='icon contents'))
+    def test_icon_is_cached(self, get_object):
+        r = Report.objects.create()
+        Application.objects.create(report=r, handle='com.example.app', version='1')
+
+        response = self.client.get('/reports/{}/icon'.format(r.pk), follow=True)
+
+        self.assertIn('max-age', response['Cache-Control'])
+        self.assertIn('immutable', response['Cache-Control'])
+
+    @patch('reports.views.Minio.get_object', autospec=True, side_effect=Exception('minio unavailable'))
+    def test_falls_back_to_default_icon_without_cache_when_minio_fails(self, get_object):
+        r = Report.objects.create()
+        Application.objects.create(report=r, handle='com.example.app', version='1')
+
+        response = self.client.get('/reports/{}/icon'.format(r.pk), follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'image/jpeg')
+        self.assertFalse(response.has_header('Cache-Control'))
+
 
 class ReportsViewTests(TestCase):
     REPORTS_PATH = '/en/reports/list/'

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -14,6 +14,22 @@ from minio import Minio
 
 from reports.models import Report, Application
 
+ICON_CACHE_MAX_AGE = 60 * 60 * 24 * 7  # 1 week
+
+_minio_client = None
+
+
+def _get_minio_client():
+    global _minio_client
+    if _minio_client is None:
+        _minio_client = Minio(
+            settings.MINIO_STORAGE_ENDPOINT,
+            access_key=settings.MINIO_STORAGE_ACCESS_KEY,
+            secret_key=settings.MINIO_STORAGE_SECRET_KEY,
+            secure=settings.MINIO_STORAGE_USE_HTTPS
+        )
+    return _minio_client
+
 
 def index(request):
     return render(request, 'reports_home.html')
@@ -78,16 +94,11 @@ def get_app_icon(request, app_id=None, handle=None):
     except Application.DoesNotExist:
         raise Http404(_('App does not exist'))
 
-    minioClient = Minio(
-        settings.MINIO_STORAGE_ENDPOINT,
-        access_key=settings.MINIO_STORAGE_ACCESS_KEY,
-        secret_key=settings.MINIO_STORAGE_SECRET_KEY,
-        secure=settings.MINIO_STORAGE_USE_HTTPS
-    )
-
     try:
-        data = minioClient.get_object(settings.MINIO_STORAGE_MEDIA_BUCKET_NAME, app.icon_path)
-        return HttpResponse(data.data, content_type='image/png')
+        data = _get_minio_client().get_object(settings.MINIO_STORAGE_MEDIA_BUCKET_NAME, app.icon_path)
+        response = HttpResponse(data.data, content_type='image/png')
+        response['Cache-Control'] = 'public, max-age={}, immutable'.format(ICON_CACHE_MAX_AGE)
+        return response
     except Exception as err:
         print(err)
         with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'android.jpeg'), 'rb') as f:

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -14,8 +14,6 @@ from minio import Minio
 
 from reports.models import Report, Application
 
-ICON_CACHE_MAX_AGE = 60 * 60 * 24 * 7  # 1 week
-
 _minio_client = None
 
 
@@ -97,7 +95,7 @@ def get_app_icon(request, app_id=None, handle=None):
     try:
         data = _get_minio_client().get_object(settings.MINIO_STORAGE_MEDIA_BUCKET_NAME, app.icon_path)
         response = HttpResponse(data.data, content_type='image/png')
-        response['Cache-Control'] = 'public, max-age={}, immutable'.format(ICON_CACHE_MAX_AGE)
+        response['Cache-Control'] = 'public, max-age={}, immutable'.format(settings.ICON_CACHE_MAX_AGE)
         return response
     except Exception as err:
         print(err)


### PR DESCRIPTION
In order to improve performance, this PR adds a cache feature for application icons

Tested locally, it still works and add the expected http headers (absent in production)