### PR TITLE
chore: improve reports page performance

### DIFF
--- a/exodus/reports/templates/reports_list.html
+++ b/exodus/reports/templates/reports_list.html
@@ -65,13 +65,13 @@
                   </div>
                   <div class="small"><b>{% trans "Version" %} {{ app.version|truncatechars_html:20 }}{% if app.source %} - {{ app.source }}{% endif %}</b></div>
                   <div>
-                    {% with nb_trackers=report.found_trackers.count %}
+                    {% with nb_trackers=report.found_trackers.all|length %}
                       <span class="mr-lg-4 mr-2">
                         <span class="badge badge-pill badge-{{ app.trackers_class }} reports">{{ nb_trackers }}</span>
                         {% blocktrans count count=nb_trackers %}tracker{% plural %}trackers{% endblocktrans %}
                       </span>
                     {% endwith %}
-                    {% with nb_perm=app.permissions|length %}
+                    {% with nb_perm=app.permission_set.all|length %}
                       <span>
                         <span class="badge badge-pill badge-{{ app.permissions_class }} reports">{{ nb_perm }}</span>
                         {% blocktrans count count=nb_perm %}permission{% plural %}permissions{% endblocktrans %}

--- a/exodus/reports/tests.py
+++ b/exodus/reports/tests.py
@@ -2,7 +2,9 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from unittest.mock import patch, Mock, ANY
 
 from reports.models import Application, Permission, Report
@@ -156,3 +158,23 @@ class ReportsViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['reports'].paginator.num_pages, 2)
         self.assertEqual(len(response.context['reports']), 1)
+
+    def _create_full_report(self, handle):
+        report = Report.objects.create()
+        report.found_trackers.set([Tracker.objects.create(name='T-' + handle).id])
+        app = Application.objects.create(report=report, handle=handle, version='1')
+        Permission.objects.create(application=app, name='android.permission.CAMERA')
+
+    def _count_list_view_queries(self):
+        with CaptureQueriesContext(connection) as ctx:
+            self.client.get(self.REPORTS_PATH)
+        return len(ctx.captured_queries)
+
+    def test_list_view_has_no_n_plus_1(self):
+        self._create_full_report('com.test.one')
+        baseline = self._count_list_view_queries()
+
+        for i in range(5):
+            self._create_full_report('com.test.{}'.format(i))
+
+        self.assertEqual(self._count_list_view_queries(), baseline)

--- a/exodus/reports/tests.py
+++ b/exodus/reports/tests.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.test import TestCase
 from unittest.mock import patch, Mock, ANY
 
-from reports.models import Application, Report
+from reports.models import Application, Permission, Report
+from trackers.models import Tracker
 
 
 class ReportsIconTests(TestCase):
@@ -124,3 +126,33 @@ class ReportsViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['reports_total_count'], 2)
+
+    def test_should_render_tracker_and_permission_count_badges(self):
+        report = Report.objects.create()
+        trackers = [Tracker.objects.create(name='Tracker{}'.format(i)) for i in range(6)]
+        report.found_trackers.set([t.id for t in trackers])
+        app = Application.objects.create(report=report, handle='com.test.app', version='1')
+        Permission.objects.create(application=app, name='android.permission.CAMERA')
+
+        response = self.client.get(self.REPORTS_PATH)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'badge-danger reports">6<')
+        self.assertContains(response, 'badge-warning reports">1<')
+
+    def test_should_render_report_without_application(self):
+        Report.objects.create()
+
+        response = self.client.get(self.REPORTS_PATH)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_should_paginate_reports(self):
+        for _ in range(settings.EX_PAGINATOR_COUNT + 1):
+            Report.objects.create()
+
+        response = self.client.get(self.REPORTS_PATH + '?page=2')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['reports'].paginator.num_pages, 2)
+        self.assertEqual(len(response.context['reports']), 1)

--- a/exodus/reports/views.py
+++ b/exodus/reports/views.py
@@ -35,13 +35,14 @@ def index(request):
 
 def get_reports(request, handle=None):
     filter = request.GET.get('filter', None)
+    base = Report.objects.select_related('application').prefetch_related('found_trackers', 'application__permission_set')
     try:
         if filter == 'no_trackers':
-            reports = Report.objects.filter(found_trackers=None).order_by('-creation_date')
+            reports = base.filter(found_trackers=None).order_by('-creation_date')
         elif filter == 'most_trackers':
-            reports = Report.objects.exclude(found_trackers=None).annotate(nb_trackers=Count('found_trackers')).order_by('-nb_trackers')
+            reports = base.exclude(found_trackers=None).annotate(nb_trackers=Count('found_trackers')).order_by('-nb_trackers')
         else:
-            reports = Report.objects.order_by('-creation_date')
+            reports = base.order_by('-creation_date')
             if handle:
                 reports = reports.filter(application__handle=handle)
     except Report.DoesNotExist:


### PR DESCRIPTION
Before this PR, the page listing reports is making a separate DB query for each report's trackers and permissions. Now, it will load all that data is fewer queries.

Nothing should change except performance (less round-trips with the DB).

I added some tests, ran them before and after the changes to confirm there is no regression.