### PR TITLE
fix(local): use new minio image for local docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     environment:
       MINIO_ROOT_USER: exodusexodus
       MINIO_ROOT_PASSWORD: exodusexodus
-    image: minio/minio:RELEASE.2024-05-10T01-41-38Z
+    image: elestio/minio:latest
     networks:
       backend:
         aliases:


### PR DESCRIPTION
The minio/minio image does not exist anymore :(

A couple of alternatives exist, used this one.
Unfortunately there is just one `latest` tag, but I think for local testing it's acceptable.